### PR TITLE
Fix the base URL

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://websitetesttest.github.io/"
+baseURL = "http://opencensus.io/"
 languageCode = "en-us"
 title = "Open Census"
 theme = "hyde"


### PR DESCRIPTION
Still pointing to the test URL, switch to the opencensus.io domain.