### PR TITLE
Change the website forking info

### DIFF
--- a/themes/hyde/layouts/_default/baseof.html
+++ b/themes/hyde/layouts/_default/baseof.html
@@ -3,6 +3,7 @@
   {{ partial "sidebar.html" . }}
     <div class="content container">
     {{ block "main" . -}}{{- end }}
+      <p class="edit"><a href="https://github.com/census-instrumentation/opencensus-website">Edit this page on GitHub</a></p>
     </div>
 
     {{ template "_internal/google_analytics_async.html" . }}

--- a/themes/hyde/layouts/partials/sidebar.html
+++ b/themes/hyde/layouts/partials/sidebar.html
@@ -13,7 +13,5 @@
       {{- end }}
       <li><a href="https://github.com/census-instrumentation" class="fork"> Fork on GitHub</a></li>
     </ul>
-    
-    <p><a href="https://github.com/census-instrumentation/opencensus-website">Edit this page on GitHub</a></p>
   </div>
 </div>

--- a/themes/hyde/layouts/partials/sidebar.html
+++ b/themes/hyde/layouts/partials/sidebar.html
@@ -13,5 +13,7 @@
       {{- end }}
       <li><a href="https://github.com/census-instrumentation" class="fork"> Fork on GitHub</a></li>
     </ul>
+    
+    <p><a href="https://github.com/census-instrumentation/opencensus-website">Edit this page on GitHub</a></p>
   </div>
 </div>

--- a/themes/hyde/layouts/partials/sidebar.html
+++ b/themes/hyde/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
       {{ range .Site.Menus.main -}}
         <li><a href="{{.URL}}"> {{ .Name }} </a></li>
       {{- end }}
-      <li><a href="https://github.com/census-instrumentation/opencensus-website" class="fork"> Fork on GitHub</a></li>
+      <li><a href="https://github.com/census-instrumentation" class="fork"> Fork on GitHub</a></li>
     </ul>
   </div>
 </div>

--- a/themes/hyde/static/css/hyde.css
+++ b/themes/hyde/static/css/hyde.css
@@ -256,3 +256,8 @@ a.sidebar-nav-item:focus {
   background-repeat: no-repeat;
   padding-left: 40px;
 }
+
+.edit {
+  font-size: .75rem;
+  text-align: right;
+}


### PR DESCRIPTION
Moved the fork for the website into the content and made the sidebar link point to the GitHub Org in response to: https://github.com/census-instrumentation/opencensus-website/pull/10#discussion_r146655203

<img width="856" alt="screen shot 2017-10-24 at 3 46 32 pm" src="https://user-images.githubusercontent.com/139938/31964645-b7b08ba6-b8d2-11e7-9896-788637ff8e8a.png">
