### PR TITLE
Avoid duplicate paragraph in docs

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -73,6 +73,8 @@ Stackdriver Monitoring.
 
 ## Who is behind OpenCensus?
 
+OpenCensus is being developed by a group of cloud providers, Application Performance Management vendors, and open source contributors. 
+
 OpenCensus was initiated by Google, and is based on instrumentation systems used
 inside of Google. OpenCensus is a complete rewrite of the Google system, and has
 no Google intellectual property.

--- a/content/index.md
+++ b/content/index.md
@@ -73,7 +73,8 @@ Stackdriver Monitoring.
 
 ## Who is behind OpenCensus?
 
-OpenCensus is being developed by a group of cloud providers, Application Performance Management vendors, and open source contributors. 
+OpenCensus is being developed by a group of cloud providers, Application
+Performance Management vendors, and open source contributors. 
 
 OpenCensus was initiated by Google, and is based on instrumentation systems used
 inside of Google. OpenCensus is a complete rewrite of the Google system, and has

--- a/content/index.md
+++ b/content/index.md
@@ -73,10 +73,6 @@ Stackdriver Monitoring.
 
 ## Who is behind OpenCensus?
 
-OpenCensus is being developed by a group of cloud providers, Application
-Performance Management vendors, and open source contributors. The project is
-hosted on GitHub and all work occurs there.
-
 OpenCensus was initiated by Google, and is based on instrumentation systems used
 inside of Google. OpenCensus is a complete rewrite of the Google system, and has
 no Google intellectual property.


### PR DESCRIPTION
Reading the introduction on the homepage, I noticed that a paragraph occured twice.
I don't know if that was on purpose, but it was a bit irritating. Therefore, I suggest removing the second occurence as it does not add any additional value.
Alternatively, we should also link to Github in the paragraph I deleted, just as we do in the first paragraph. 😉 