### PR TITLE
Link to API ref docs from docs page, update javadoc URL

### DIFF
--- a/static/v2/docs.html
+++ b/static/v2/docs.html
@@ -188,7 +188,7 @@
                                         <td><a href="cpp.html" class="doc1">Quickstart Guide</a></td>
                                     </tr>
                                     <tr>
-                                        <td><a href="" class="doc1">API Reference</a></td>
+                                        <td><a href="https://github.com/census-instrumentation/opencensus-cpp" class="doc1">API Reference</a></td>
                                     </tr>
                                     <tr>
                                         <td><a href="" class="=doc1">&nbsp;</a></td>
@@ -226,7 +226,7 @@
                                         <td><a href="go.html" class="doc1">Quickstart Guide</a></td>
                                     </tr>
                                     <tr>
-                                        <td><a href="" class="doc1">API Reference</a></td>
+                                        <td><a href="https://godoc.org/go.opencensus.io" class="doc1">API Reference</a></td>
                                     </tr>
                                     <tr>
                                         <td><a href="" class="=doc1">&nbsp;</a></td>
@@ -243,7 +243,7 @@
                                         <td><a href="java.html" class="doc1">Quickstart Guide</a></td>
                                     </tr>
                                     <tr>
-                                        <td><a href="" class="doc1">API Reference</a></td>
+                                        <td><a href="https://www.javadoc.io/doc/io.opencensus/opencensus-api" class="doc1">API Reference</a></td>
                                     </tr>
                                     <tr>
                                         <td><a href="" class="=doc1">&nbsp;</a></td>

--- a/static/v2/reference.html
+++ b/static/v2/reference.html
@@ -185,7 +185,7 @@
                             <h4><a href="https://godoc.org/go.opencensus.io">Go API</a></h4>
                             <br><hr><br>
                                                         
-                            <h4><a href="https://mvnrepository.com/artifact/io.opencensus">Java API</a></h4>
+                            <h4><a href="https://www.javadoc.io/doc/io.opencensus/opencensus-api">Java API</a></h4>
                             <br><br>
                             <!--
                             <h4><a href="https://github.com/census-instrumentation/opencensus-csharp">C#/.NET API</a></h4>


### PR DESCRIPTION
Adds links to the API reference documentation from the docs page. Also updated the Java API reference docs to point at javadoc.io rendered version.