### PR TITLE
Updated README Hugo version and pointing tutorials link to spanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repo contains the source for the [opencensus.io][website] website.
 ## Contributing
 
 Contributions are highly appreciated! Please follow the steps below to contribute:
+Important to Note: This site is currently built on Hugo v0.31.1 found [Here][version-control].
+Use v0.31.1 to run your edits locally.
 
 1. Install [Hugo][install-hugo].
 2. Check out the website source:
@@ -18,20 +20,30 @@ $ cd opencensus-website
 ```
 $ hugo
 
-$ firebase serve
+$ hugo serve
 
-=== Serving from '/Users/me/opencensus-website'...
+Started building sites ...
 
-i  hosting: Serving hosting files from: public/
+Built site for language en:
+...
+...
+total in ms
 
-✔  hosting: Local server: http://localhost:5000
+Watching for changes in /Users/you/Desktop/opencensus-website/{content,layouts,static,themes}
+
+Serving pages from memory
+
+Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
+
+Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 
 Press Ctrl+C to stop
 ```
-4. Go to http://localhost:5000 to display the rendered website locally.
+4. Go to http://localhost:1313/ to display the rendered website locally.
 5. If it all looks good, create a pull request with the changes.
 6. Once your PR is approved and merged, the website will be automatically regenerated and published.
 
 
 [website]: http://opencensus.io
 [install-hugo]: https://gohugo.io/getting-started/installing/
+[version-control]: https://github.com/gohugoio/hugo/releases/tag/v0.31.1

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -21,7 +21,7 @@
                         <p><a href="../overview/index.html">Overview</a></p><br>
                         <p><a href="../quickstart/index.html">Quickstart</a></p><br>
                         <p><a href="../guides/index.html">Guides</a></p><br>
-                        <p><a href="https://github.com/census-instrumentation" target="_blank">Tutorials</a></p><br>
+                        <p><a href="../spanner/index.html">Tutorials</a></p><br>
                         <p><a href="../reference/index.html">API Reference</a></p><br>
 					</div>
 					<!-- DOCUMENTS END -->

--- a/layouts/partials/index_footer.html
+++ b/layouts/partials/index_footer.html
@@ -21,7 +21,7 @@
                         <p><a href="./overview/index.html">Overview</a></p><br>
                         <p><a href="./quickstart/index.html">Quickstart</a></p><br>
                         <p><a href="./guides/index.html">Guides</a></p><br>
-                        <p><a href="https://github.com/census-instrumentation" target="_blank">Tutorials</a></p><br>
+                        <p><a href="./spanner/index.html">Tutorials</a></p><br>
                         <p><a href="./reference/index.html">API Reference</a></p><br>
 					</div>
 					<!-- DOCUMENTS END -->

--- a/themes/census/README.md
+++ b/themes/census/README.md
@@ -6,6 +6,8 @@ This repo contains the source for the [opencensus.io][website] website.
 ## Contributing
 
 Contributions are highly appreciated! Please follow the steps below to contribute:
+Important to Note: This site is currently built on Hugo v0.31.1 found [Here][version-control].
+Use v0.31.1 to run your edits locally.
 
 1. Install [Hugo][install-hugo].
 2. Check out the website source:
@@ -18,20 +20,30 @@ $ cd opencensus-website
 ```
 $ hugo
 
-$ firebase serve
+$ hugo serve
 
-=== Serving from '/Users/me/opencensus-website'...
+Started building sites ...
 
-i  hosting: Serving hosting files from: public/
+Built site for language en:
+...
+...
+total in ms
 
-✔  hosting: Local server: http://localhost:5000
+Watching for changes in /Users/you/Desktop/opencensus-website/{content,layouts,static,themes}
+
+Serving pages from memory
+
+Running in Fast Render Mode. For full rebuilds on change: hugo server --disableFastRender
+
+Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 
 Press Ctrl+C to stop
 ```
-4. Go to http://localhost:5000 to display the rendered website locally.
+4. Go to http://localhost:1313/ to display the rendered website locally.
 5. If it all looks good, create a pull request with the changes.
 6. Once your PR is approved and merged, the website will be automatically regenerated and published.
 
 
 [website]: http://opencensus.io
 [install-hugo]: https://gohugo.io/getting-started/installing/
+[version-control]: https://github.com/gohugoio/hugo/releases/tag/v0.31.1


### PR DESCRIPTION
I have updated README for Hugo version control. We are working on fixing this, so the site builds on the current version of Hugo (which it currently will not). Tutorials will point to spanner/ at this time. Once we have a couple more tutorials, we will collect them into a stand-alone tutorials/ page.