### PR TITLE
Update list of supported languages and exporters

### DIFF
--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -49,6 +49,11 @@ date = "2018-05-11T12:09:08-05:00"
 	  <td data-label="Stats: &nbsp; ">Supported</td>
 	</tr>
 	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-node" target="_blank" class="gloss1">Node.js</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">In Progress</td>
+	</tr>
+	<tr>
 	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-php" target="_blank" class="gloss1">PHP</a></td>
 	  <td data-label="Tracing: &nbsp; ">Supported</td>
 	  <td data-label="Stats: &nbsp; ">Planned</td>
@@ -77,53 +82,82 @@ date = "2018-05-11T12:09:08-05:00"
   <thead>
 	<tr>
 	  <th scope="col">Backend</th>
+	  <th scope="col">C++</th>
+	  <th scope="col">Erlang</th>
 	  <th scope="col">Go</th>
 	  <th scope="col">Java</th>
-	  <th scope="col">Erlang</th>
-	  <th scope="col">C++</th>
+		<th scope="col">Node.js</th>
+		<th scope="col">PHP</th>
 	  <th scope="col">Python</th>
+		<th scope="col">Ruby</th>
 	</tr>
   </thead>
   <tbody>
 	<tr>
-	  <td data-label="Backend: &nbsp; ">SignalFX</td>
-	  <td data-label="Go: &nbsp; " class="tall">No <a href="https://github.com/census-instrumentation/opencensus-go/issues/360" target="_blank" class="gloss1">(open issue)</a></td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">No</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Prometheus</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</span></a></td>
-	  <td data-label="Erlang: &nbsp; ">Yes</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
+	  <td data-label="Backend: &nbsp; ">Instana</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">–</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>
 	<tr>
 	  <td data-label="Backend: &nbsp; ">Jaeger</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">No</td>
-	  <td data-label="Erlang: &nbsp; ">No</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Prometheus</td>
+	  <td data-label="C++: &nbsp; ">{{< sc_statsExporter />}}</td>
+	  <td data-label="Erlang: &nbsp; ">{{< sc_statsExporter />}}</td>
+	  <td data-label="Go: &nbsp; ">{{< sc_statsExporter />}}</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_statsExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">SignalFX</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">–</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_statsExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>
 	<tr>
 	  <td data-label="Backend: &nbsp; ">Stackdriver</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">Yes (trace only)</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">Yes</td>
+	  <td data-label="C++: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
+	  <td data-label="Erlang: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>
 	<tr>
 	  <td data-label="Backend: &nbsp; ">Zipkin</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">Yes</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
+	  <td data-label="C++: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="Erlang: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>
   </tbody>
 </table>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1533,3 +1533,32 @@ text-indent: -1em;
   -webkit-hyphens: auto;
   hyphens: auto;
 }
+
+/* --------------------------------------
+  Supported exporters page
+-----------------------------------------*/
+.stats-exporter, .trace-exporter {
+  display: inline-block;
+  padding: .05em .4em;
+  font-size: 75%;
+  font-weight: 700;
+  text-align: center;
+  white-space: nowrap;
+  border-radius: .25rem;
+}
+
+/* Disable bootstrap defaults for abbr elements */
+.stats-exporter[title], .trace-exporter[title] {
+  text-decoration: none;
+  border-bottom: 0;
+}
+
+.stats-exporter {
+  color: #fff;
+  background-color: #17a2b8;
+}
+
+.trace-exporter {
+  color: #fff;
+  background-color: #007bff;
+}

--- a/themes/census/layouts/shortcodes/sc_statsExporter.html
+++ b/themes/census/layouts/shortcodes/sc_statsExporter.html
@@ -1,0 +1,1 @@
+<abbr title="Stats Exporter" data-inner="{{.Inner}}" class="stats-exporter">S</abbr>

--- a/themes/census/layouts/shortcodes/sc_traceExporter.html
+++ b/themes/census/layouts/shortcodes/sc_traceExporter.html
@@ -1,0 +1,1 @@
+<abbr title="Trace Exporter" data-inner="{{.Inner}}" class="trace-exporter">T</abbr>


### PR DESCRIPTION
I wanted to get an idea about OpenCensus' support matrix is. While doing
so, I discovered that the roadmap documentation is outdated. This PR
updates the roadmap document. To do so, I went through all the
OpenCensus repos to get an idea what the exporters actually support
(many only support either stats or traces).

 - add Node.js as supported language
 - sort languages and exporters alphabetically
 - update exporter support matrix
 - document PHP, Node.js and Ruby exporter support
 - clearly differentiate between trace and stats support of exporters

This is what the support matrix looks like with this PR (tooltip being used to explain badges, mouse cursor not visible in screenshot):

<img width="992" alt="screen shot 2018-06-17 at 18 21 52" src="https://user-images.githubusercontent.com/596443/41509955-50f69222-725c-11e8-84c8-b3920a5a505f.png">
