### PR TITLE
Update and ensure language & exporter list consistency

### DIFF
--- a/content/faq.md
+++ b/content/faq.md
@@ -36,112 +36,14 @@ date = "2018-05-10T14:14:33-05:00"
 <a href="#accordion3" aria-expanded="false" aria-controls="accordion3" class="accordion-title accordionTitle js-accordionTrigger">+ What languages &amp; integrations does OpenCensus support?</a>
 </dt>
 <dd class="accordion-content accordionItem is-collapsed" id="accordion3" aria-hidden="true">
-<table>
-  <thead>
-    <tr>
-	  <th scope="col">Language</th>
-	  <th scope="col">Tracing</th>
-	  <th scope="col">Stats</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-	  <td data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-cpp" target="_blank"><span>C++</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-erlang" target="_blank"><span>Erlang</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-go" target="_blank"><span>Go</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-java" target="_blank"><span>Java (JVM, OpenJDK, Android)</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-php" target="_blank"><span>PHP</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Planned</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-python" target="_blank"><span>Python</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">In Progress</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-ruby" target="_blank"><span>Ruby</span></a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Planned</td>
-	</tr>
-  </tbody>
-</table>
+{{< sc_supportedLanguages />}}
 </dd>
 <hr>
 <dt>
 <a href="#accordion4" aria-expanded="false" aria-controls="accordion4" class="accordion-title accordionTitle js-accordionTrigger">+ What Exporters does OpenCensus support?</a>
 </dt>
 <dd class="accordion-content accordionItem is-collapsed" id="accordion4" aria-hidden="true">
-<table>
-  <thead>
-	<tr>
-	  <th scope="col">Backend</th>
-	  <th scope="col">Go</th>
-	  <th scope="col">Java</th>
-	  <th scope="col">Erlang</th>
-	  <th scope="col">C++</th>
-	  <th scope="col">Python</th>
-	</tr>
-  </thead>
-  <tbody>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">SignalFX</td>
-	  <td data-label="Go: &nbsp; " class="tall">No <a href="https://github.com/census-instrumentation/opencensus-go/issues/360" target="_blank"><span>(open issue)</span></a></td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">No</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Prometheus</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</span></a></td>
-	  <td data-label="Erlang: &nbsp; ">Yes</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Jaeger</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">No</td>
-	  <td data-label="Erlang: &nbsp; ">No</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Stackdriver</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">Yes (trace only)</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">Yes</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Zipkin</td>
-	  <td data-label="Go: &nbsp; ">Yes</td>
-	  <td data-label="Java: &nbsp; ">Yes</td>
-	  <td data-label="Erlang: &nbsp; ">Yes</td>
-	  <td data-label="C++: &nbsp; ">No</td>
-	  <td data-label="Python: &nbsp; ">No</td>
-	</tr>
-  </tbody>
-</table>
+{{< sc_supportedExporters />}}
 </dd>
 <hr>
 <dt>

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -99,8 +99,8 @@ date = "2018-05-11T12:09:08-05:00"
 	  <td data-label="Erlang: &nbsp; ">–</td>
 	  <td data-label="Go: &nbsp; ">–</td>
 	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">–</td>
-		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="PHP: &nbsp; ">–</td>
 	  <td data-label="Python: &nbsp; ">–</td>
 		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>
@@ -110,8 +110,8 @@ date = "2018-05-11T12:09:08-05:00"
 	  <td data-label="Erlang: &nbsp; ">–</td>
 	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}}</td>
 	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">–</td>
-		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
+	  <td data-label="PHP: &nbsp; ">–</td>
 	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
 		<td data-label="Ruby: &nbsp; ">–</td>
 	</tr>

--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -19,57 +19,7 @@ date = "2018-05-11T12:09:08-05:00"
 #### Languages  
 &nbsp;  
 
-<table>
-  <thead>
-    <tr>
-	  <th scope="col">Language</th>
-	  <th scope="col">Tracing</th>
-	  <th scope="col">Stats</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-	  <td data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-cpp" target="_blank" class="gloss1">C++</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-erlang" target="_blank" class="gloss1">Erlang</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-go" target="_blank" class="gloss1">Go</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-java" target="_blank" class="gloss1">Java (JVM, OpenJDK, Android)</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Supported</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-node" target="_blank" class="gloss1">Node.js</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">In Progress</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-php" target="_blank" class="gloss1">PHP</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Planned</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-python" target="_blank" class="gloss1">Python</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">In Progress</td>
-	</tr>
-	<tr>
-	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-ruby" target="_blank" class="gloss1">Ruby</a></td>
-	  <td data-label="Tracing: &nbsp; ">Supported</td>
-	  <td data-label="Stats: &nbsp; ">Planned</td>
-	</tr>
-  </tbody>
-</table>
+{{< sc_supportedLanguages />}}
 
 &nbsp;  
 
@@ -78,89 +28,7 @@ date = "2018-05-11T12:09:08-05:00"
 
 #### Exporters  
 
-<table>
-  <thead>
-	<tr>
-	  <th scope="col">Backend</th>
-	  <th scope="col">C++</th>
-	  <th scope="col">Erlang</th>
-	  <th scope="col">Go</th>
-	  <th scope="col">Java</th>
-		<th scope="col">Node.js</th>
-		<th scope="col">PHP</th>
-	  <th scope="col">Python</th>
-		<th scope="col">Ruby</th>
-	</tr>
-  </thead>
-  <tbody>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Instana</td>
-	  <td data-label="C++: &nbsp; ">–</td>
-	  <td data-label="Erlang: &nbsp; ">–</td>
-	  <td data-label="Go: &nbsp; ">–</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">–</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Jaeger</td>
-	  <td data-label="C++: &nbsp; ">–</td>
-	  <td data-label="Erlang: &nbsp; ">–</td>
-	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Prometheus</td>
-	  <td data-label="C++: &nbsp; ">{{< sc_statsExporter />}}</td>
-	  <td data-label="Erlang: &nbsp; ">{{< sc_statsExporter />}}</td>
-	  <td data-label="Go: &nbsp; ">{{< sc_statsExporter />}}</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_statsExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">–</td>
-		<td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">–</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">SignalFX</td>
-	  <td data-label="C++: &nbsp; ">–</td>
-	  <td data-label="Erlang: &nbsp; ">–</td>
-	  <td data-label="Go: &nbsp; ">–</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_statsExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">–</td>
-		<td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">–</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Stackdriver</td>
-	  <td data-label="C++: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
-	  <td data-label="Erlang: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}} {{< sc_statsExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-	<tr>
-	  <td data-label="Backend: &nbsp; ">Zipkin</td>
-	  <td data-label="C++: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Erlang: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Go: &nbsp; ">{{< sc_traceExporter />}}</td>
-	  <td data-label="Java: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Node.js: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="PHP: &nbsp; ">–</td>
-	  <td data-label="Python: &nbsp; ">{{< sc_traceExporter />}}</td>
-		<td data-label="Ruby: &nbsp; ">–</td>
-	</tr>
-  </tbody>
-</table>
+{{< sc_supportedExporters />}}
 
 &nbsp;  
 

--- a/layouts/partials/statsExporter.html
+++ b/layouts/partials/statsExporter.html
@@ -1,0 +1,1 @@
+<abbr title="Stats Exporter" class="stats-exporter">S</abbr>

--- a/layouts/partials/traceExporter.html
+++ b/layouts/partials/traceExporter.html
@@ -1,0 +1,1 @@
+<abbr title="Trace Exporter" class="trace-exporter">T</abbr>

--- a/themes/census/layouts/shortcodes/sc_statsExporter.html
+++ b/themes/census/layouts/shortcodes/sc_statsExporter.html
@@ -1,1 +1,0 @@
-<abbr title="Stats Exporter" data-inner="{{.Inner}}" class="stats-exporter">S</abbr>

--- a/themes/census/layouts/shortcodes/sc_supportedExporters.html
+++ b/themes/census/layouts/shortcodes/sc_supportedExporters.html
@@ -1,0 +1,83 @@
+<table data-inner="{{.Inner}}">
+  <thead>
+	<tr>
+	  <th scope="col">Backend</th>
+	  <th scope="col">C++</th>
+	  <th scope="col">Erlang</th>
+	  <th scope="col">Go</th>
+	  <th scope="col">Java</th>
+		<th scope="col">Node.js</th>
+		<th scope="col">PHP</th>
+	  <th scope="col">Python</th>
+		<th scope="col">Ruby</th>
+	</tr>
+  </thead>
+  <tbody>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Instana</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">–</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Node.js: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Jaeger</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Node.js: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Prometheus</td>
+	  <td data-label="C++: &nbsp; ">{{ partial "statsExporter.html" . }}</td>
+	  <td data-label="Erlang: &nbsp; ">{{ partial "statsExporter.html" . }}</td>
+	  <td data-label="Go: &nbsp; ">{{ partial "statsExporter.html" . }}</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "statsExporter.html" . }}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">SignalFX</td>
+	  <td data-label="C++: &nbsp; ">–</td>
+	  <td data-label="Erlang: &nbsp; ">–</td>
+	  <td data-label="Go: &nbsp; ">–</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "statsExporter.html" . }}</td>
+		<td data-label="Node.js: &nbsp; ">–</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">–</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Stackdriver</td>
+	  <td data-label="C++: &nbsp; ">{{ partial "traceExporter.html" . }} {{ partial "statsExporter.html" . }}</td>
+	  <td data-label="Erlang: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Go: &nbsp; ">{{ partial "traceExporter.html" . }} {{ partial "statsExporter.html" . }}</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "traceExporter.html" . }} {{ partial "statsExporter.html" . }}</td>
+		<td data-label="Node.js: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+	<tr>
+	  <td data-label="Backend: &nbsp; ">Zipkin</td>
+	  <td data-label="C++: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Erlang: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Go: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+	  <td data-label="Java: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="Node.js: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="PHP: &nbsp; ">–</td>
+	  <td data-label="Python: &nbsp; ">{{ partial "traceExporter.html" . }}</td>
+		<td data-label="Ruby: &nbsp; ">–</td>
+	</tr>
+  </tbody>
+</table>

--- a/themes/census/layouts/shortcodes/sc_supportedLanguages.html
+++ b/themes/census/layouts/shortcodes/sc_supportedLanguages.html
@@ -1,0 +1,51 @@
+<table data-inner="{{.Inner}}">
+  <thead>
+    <tr>
+	  <th scope="col">Language</th>
+	  <th scope="col">Tracing</th>
+	  <th scope="col">Stats</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+	  <td data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-cpp" target="_blank" class="gloss1">C++</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Supported</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-erlang" target="_blank" class="gloss1">Erlang</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Supported</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-go" target="_blank" class="gloss1">Go</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Supported</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-java" target="_blank" class="gloss1">Java (JVM, OpenJDK, Android)</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Supported</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-node" target="_blank" class="gloss1">Node.js</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">In Progress</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-php" target="_blank" class="gloss1">PHP</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Planned</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-python" target="_blank" class="gloss1">Python</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">In Progress</td>
+	</tr>
+	<tr>
+	  <td scope="row" data-label="Language: &nbsp; "><a href="https://github.com/census-instrumentation/opencensus-ruby" target="_blank" class="gloss1">Ruby</a></td>
+	  <td data-label="Tracing: &nbsp; ">Supported</td>
+	  <td data-label="Stats: &nbsp; ">Planned</td>
+	</tr>
+  </tbody>
+</table>

--- a/themes/census/layouts/shortcodes/sc_traceExporter.html
+++ b/themes/census/layouts/shortcodes/sc_traceExporter.html
@@ -1,1 +1,0 @@
-<abbr title="Trace Exporter" data-inner="{{.Inner}}" class="trace-exporter">T</abbr>


### PR DESCRIPTION
I noticed that the supported languages and exporters are also listed within the FAQ section (my previous PR only updated the roadmap file). This PR…

 - lists Instana and Jaeger Node.js exporters as supported
 - ensures that roadmap and FAQ refer to the same support tables (via shortcode/partials)