### PR TITLE
Add GitHub to the top navigation

### DIFF
--- a/layouts/partials/index_nav.html
+++ b/layouts/partials/index_nav.html
@@ -63,6 +63,7 @@
 							<li><a href="/roadmap">Roadmap</a></li>
 							<li><a href="/blog">Blog</a></li>
 							<li><a href="/faq">FAQ</a></li>
+							<li><a href="https://github.com/census-instrumentation">GitHub</a></li>
 							<li><a href="/about">About</a></li>
 						</ul>
 					</div><!-- /.navbar-collapse -->

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -62,6 +62,7 @@
 								<li><a href="/roadmap">Roadmap</a></li>
 								<li><a href="/blog">Blog</a></li>
 								<li><a href="/faq">FAQ</a></li>
+								<li><a href="https://github.com/census-instrumentation">GitHub</a></li>
 								<li><a href="/about">About</a></li>
 							</ul>
 						</div><!-- /.navbar-collapse -->


### PR DESCRIPTION
I have seen multiple users finding it hard to find a link
to our GitHub organization. Add a link to the top nav
to make it more visible.

Fixes #111.