### PR TITLE
Make the whitespace around list items compatible to the regular text

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1567,13 +1567,14 @@ text-indent: -1em;
   margin: 20px 0px;
 }
 
-.content ul {
+.content ul, .content ol {
   margin: 20px 0px;
 }
 
-.content ul li {
+.content ul li, .content ol li {
   list-style-type: circle;
-  margin: 0px 0px 5px 30px;
+  margin: 0px 0px 10px 40px;
+  line-height: 27px;
 }
 
 .content a {


### PR DESCRIPTION
Paragraphs and list items have different settings for line height
and margin/padding. Make them consistent.