### PR TITLE
Revise the Go quickstart

### DIFF
--- a/content/docs.md
+++ b/content/docs.md
@@ -14,7 +14,6 @@ OpenCensus terminology is explained at the [glossary](/glossary).
 
 ---
 
-&nbsp;
 #### OpenCensus by Language
 
 <div class="col-md-12 box" style="margin-top:20px">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1581,3 +1581,7 @@ text-indent: -1em;
   color: #C1272D;
   font-weight: bold;
 }
+
+.content h1, .content h2, .content h3, .content h4, .content h5 {
+  margin: 20px 0px;
+}


### PR DESCRIPTION
* Have more focus on the gRPC/HTTP integrations.
* Show how to use the low-level APIs for custom instrumentation.
* Mention exporters.
* Add link to the GitHub repo.

Fixes #159.