### PR TITLE
content: update wording from offline suggestions

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -15,10 +15,10 @@ class: "no-pagination no-top-border-header no-search max-text-width"
 
 {{<button class="btn-light" icon="true" href="/quickstart">}}Quickstart{{</button>}}
 
-##### Can I use OpenCensus in my project?
+##### How can I use OpenCensus in my project?
 Our libraries support Go, Java, C++, Ruby, Erlang, Python, and PHP.
 
-Supported backends include Datadog, Instana, Jaeger, SignalFX, Stackdriver, and Zipkin. You can also [add support for other backends](/).
+Supported backends include Datadog, Instana, Jaeger, SignalFX, Stackdriver, and Zipkin. You can also [add support for other backends](/core-concepts/exporters/).
 
 {{<button class="btn-light" icon="true" href="/introduction/language-support">}}Language Support{{</button>}}
 
@@ -31,12 +31,24 @@ OpenCensus originates from Google, where a set of libraries called Census were u
 
 {{<button class="btn-light" icon="true" href="/community">}}Community{{</button>}}
 
-##### What are *Metrics* and *Tracing*?
+{{<button class="btn-light" icon="true" href="https://gitter.im/census-instrumentation/Lobby">}}Gitter{{</button>}}
+
+##### What are *Metrics* and *Traces*?
 
 [**Metrics**](/core-concepts/metrics) are any quantifiable piece of data that you would like to track, such as latency in a service or database, request content length, or number of open file descriptors. Viewing graphs of your metrics can help you understand and gauge the performance and overall quality of your application and set of services.
 
 [**Traces**](/core-concepts/tracing) show you how a request propagates throughout your application or set of services. Viewing graphs of your traces can help you understand the bottlenecks in your architecture by visualizing how data flows between all of your services.
 
+##### How can I contribute to OpenCensus?
+* Help people on the discussion forums
+* Tell us your success stories using OpenCensus
+* Tell us how we can improve OpenCensus, and help us do it
+* Contribute to an existing library or create one for a new language
+
 ##### Partners & Contributors
 
 {{<partners>}}
+
+{{<button class="btn-light" icon="true" href="https://gitter.im/census-instrumentation/Lobby">}}Discussion forum{{</button>}}
+
+{{<button class="btn-light" icon="true" href="https://github.com/census-instrumentation/">}}Contribute{{</button>}}

--- a/content/integrations/redis/Java.md
+++ b/content/integrations/redis/Java.md
@@ -30,6 +30,8 @@ jedis|https://github.com/opencensus-integrations/jedis
 - [Enabling observability](#enabling-observability)
 - [End to end example](#end-to-end-example)
     - [Running it](#running-it)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
 
 #### Generating the JAR
 
@@ -251,4 +253,8 @@ public class JedisOpenCensus {
 mvn install && mvn exec:java -Dexec.mainClass=io.opencensus.tutorials.jedis.JedisOpenCensus
 ```
 
-#### Examining your metrics and traces
+##### Viewing your metrics
+Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
+
+##### Viewing your traces
+Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)


### PR DESCRIPTION
* Re-phrase some wording to make rhetorical questions
more actionable such as from:
    "Can I use OpenCensus in my project?"
to
    "How can I use OpenCensus in my project"

* Add buttons to links that add visibility to resources such as
Gitter and Github

* Update wording from:
    "What are Metrics and Tracing?"
to
    "What are Metrics and Traces?"
because the explanation in the sub-text uses
"Traces" instead of "Tracing"

* Add information for how users can contribute to OpenCensus. This
perhaps will encourage more involvement and inclusion

* Add links for viewing traces and metrics in
    content/integration/redis/Java

All the above are suggestions from core users via offline discussions.