### PR TITLE
content/_index: move buttons to relevant section. Also addresses #200

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -45,10 +45,10 @@ OpenCensus originates from Google, where a set of libraries called Census were u
 * Tell us how we can improve OpenCensus, and help us do it
 * Contribute to an existing library or create one for a new language
 
-##### Partners & Contributors
-
-{{<partners>}}
-
 {{<button class="btn-light" icon="true" href="https://gitter.im/census-instrumentation/Lobby">}}Discussion forum{{</button>}}
 
 {{<button class="btn-light" icon="true" href="https://github.com/census-instrumentation/">}}Contribute{{</button>}}
+
+##### Partners & Contributors
+
+{{<partners>}}


### PR DESCRIPTION
Moves homepage buttons in to a relevant section and potentially fixes the below issue:
<img width="441" alt="screen shot 2018-07-26 at 1 45 57 pm" src="https://user-images.githubusercontent.com/5974764/43288028-8c880896-90db-11e8-927f-fc91d66344c2.png">
