### PR TITLE
content/*: update Java OC version to 0.15.0 from 0.14.0

### DIFF
--- a/content/integrations/google_cloud_storage/Go.md
+++ b/content/integrations/google_cloud_storage/Go.md
@@ -130,11 +130,11 @@ func main() {
 	}
 	defer sd.Flush()
 
-        // Register the trace exporter
-        trace.RegisterExporter(sd)
+	// Register the trace exporter
+	trace.RegisterExporter(sd)
 
-        // Register the stats exporter
-        view.RegisterExporter(sd)
+	// Register the stats exporter
+	view.RegisterExporter(sd)
 
 	// And for the custom transport to enable metrics collection
 	ctx := context.Background()

--- a/content/quickstart/java/metrics.md
+++ b/content/quickstart/java/metrics.md
@@ -68,7 +68,7 @@ Put this in your newly generated `pom.xml` file:
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <build>
@@ -247,7 +247,7 @@ To enable metrics, we’ll declare the dependencies in your `pom.xml` file:
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>
@@ -1408,7 +1408,7 @@ public class Repl {
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>

--- a/content/quickstart/java/tracing.md
+++ b/content/quickstart/java/tracing.md
@@ -61,7 +61,7 @@ Put this in your newly generated `pom.xml` file:
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <build>
@@ -239,7 +239,7 @@ To enable tracing, we’ll declare the dependencies in your `pom.xml` file:
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>
@@ -468,7 +468,7 @@ To turn on Stackdriver Tracing, we’ll need to declare the Stackdriver dependen
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>

--- a/content/supported-exporters/Java/Instana.md
+++ b/content/supported-exporters/Java/Instana.md
@@ -31,7 +31,7 @@ To create the trace exporter, you'll need to:
 ```xml
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>

--- a/content/supported-exporters/Java/Jaeger.md
+++ b/content/supported-exporters/Java/Jaeger.md
@@ -39,7 +39,7 @@ If using Maven, add these to your pom.xml file
 ```xml
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+  <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
 </properties>
 
 <dependencies>

--- a/content/supported-exporters/Java/Prometheus.md
+++ b/content/supported-exporters/Java/Prometheus.md
@@ -41,7 +41,7 @@ Add this to your pom.xml file:
 ```xml
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>

--- a/content/supported-exporters/Java/SignalFx.md
+++ b/content/supported-exporters/Java/SignalFx.md
@@ -32,7 +32,7 @@ OpenCensus Java has support for this exporter available through the package:
 ```xml
 <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+    <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
 </properties>
 
 <dependencies>

--- a/content/supported-exporters/Java/Stackdriver.md
+++ b/content/supported-exporters/Java/Stackdriver.md
@@ -45,7 +45,7 @@ To create the exporters, you'll need to:
 ```xml
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
     </properties>
 
     <dependencies>

--- a/content/supported-exporters/Java/Zipkin.md
+++ b/content/supported-exporters/Java/Zipkin.md
@@ -34,7 +34,7 @@ If using Maven, add these to your pom.xml file
 ```xml
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  <opencensus.version>0.14.0</opencensus.version> <!-- The OpenCensus version to use -->
+  <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
 </properties>
 
 <dependencies>


### PR DESCRIPTION
* Update Java OpenCensus version from 0.14.0 to 0.15.0
which is the latest
* In content/integrations/google_cloud_storage, go fmt
the Go snippet as it mixed tabs with spaces


Thanks to @songy23 for the offline feedback!