### PR TITLE
content/quickstart/Go: remove premature span in samples

### DIFF
--- a/content/quickstart/go/tracing.md
+++ b/content/quickstart/go/tracing.md
@@ -110,8 +110,6 @@ func readLine(br *bufio.Reader) ([]byte, error) {
 // processLine takes in a line of text and
 // transforms it. Currently it just capitalizes it.
 func processLine(in []byte) (out []byte, err error) {
-	defer span.End()
-
 	return bytes.ToUpper(in), nil
 }
 {{</highlight>}}
@@ -197,8 +195,6 @@ func readLine(br *bufio.Reader) ([]byte, error) {
 // processLine takes in a line of text and
 // transforms it. Currently it just capitalizes it.
 func processLine(in []byte) (out []byte, err error) {
-	defer span.End()
-
 	return bytes.ToUpper(in), nil
 }
 {{</highlight>}}


### PR DESCRIPTION
Remove the premature introduction of a
```go
defer span.End()
```

before tracing was introduced.

Fixes #213