### PR TITLE
Fix a doc link in Overview.

### DIFF
--- a/content/introduction/overview.md
+++ b/content/introduction/overview.md
@@ -17,7 +17,7 @@ After [instrumenting](https://en.wikipedia.org/wiki/Instrumentation_(computer_pr
 {{<button href="/quickstart" class="btn-info">}}Visit the Quickstart guide to begin{{</button>}}
 
 {{% notice note %}}
-Already familiar with OpenCensus? [Click here](https://opencensus.io/docs/) for a full overview of our API to get started.
+Already familiar with OpenCensus? [Click here](https://opencensus.io/language-support/) for a full overview of our API to get started.
 {{% /notice %}}
 
 ## Why OpenCensus?


### PR DESCRIPTION
https://opencensus.io/docs/ has been removed.