### PR TITLE
Remove unneeded scrollbars on tables

### DIFF
--- a/static/css/content.css
+++ b/static/css/content.css
@@ -80,12 +80,12 @@ article section.page.resized-logo img:first-child {
 }
 
 table td {
-  overflow: scroll;
+  overflow: auto;
 }
 
-table td code {
+table td code,
+table td a {
   white-space: nowrap;
-  overflow: scroll;
 }
 
 article section.page.no-pagination .chevrons {


### PR DESCRIPTION
Fixes #235 

This PR does two things:

1. Removes `overflow: scroll` for all `td` elements
2. Applies `white-space: nowrap` to `code` and `a` elements.

Scenarios:

The website's usage of table cells currently compose of these items:

*  Explanatory text
* URL
* Code snippet

This PR's styling guide operates under the following framework:

The contents of an *explanatory text* is immediately informative to the eye and thus is granted the ability to take up multiple lines.

The contents of a *URL*  is not important to the eye. The only thing that may be of interest to the user is the ability to see the root domain, but it is not relevant. This should only be on one line (`white-space: nowrap`) and scrollable (`overflow: scroll`).

The contents of a *code snippet*, while potentially important at a glance, is more important during implementation. This should only be on one line and scrollable.

Demo:
<img width="854" alt="screen shot 2018-08-15 at 12 46 26 pm" src="https://user-images.githubusercontent.com/5974764/44169856-8a3d3c00-a08a-11e8-813a-7a150fbc10d0.png">

<img width="824" alt="screen shot 2018-08-15 at 12 46 21 pm" src="https://user-images.githubusercontent.com/5974764/44169866-8f01f000-a08a-11e8-989f-5d066e62563a.png">
