### PR TITLE
More attention grabbing notes

### DIFF
--- a/content/guides/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Go/Jaeger.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
-{{% notice note %}}
-This guide makes use of Jaeger for visualizing your data. For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
-{{% /notice %}}
-
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -23,6 +19,10 @@ It is used for monitoring and troubleshooting microservices-based distributed sy
 * Performance / latency optimization
 
 OpenCensus Go has support for this exporter available through package [go.opencensus.io/exporter/jaeger](https://godoc.org/go.opencensus.io/exporter/jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Go/Prometheus.md
@@ -9,16 +9,16 @@ aliases: [/supported-exporters/go/prometheus]
 
 ![](/img/prometheus-logo.png)
 
-{{% notice note %}}
-This guide makes use of Prometheus for receiving and visualizing your data. For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
-{{% /notice %}}
-
 Prometheus is a monitoring system that collects metrics, by scraping
 exposed endpoints at regular intervals, evaluating rule expressions.
 It can also trigger alerts if certain conditions are met.
 
 OpenCensus Go allows exporting stats to Prometheus by means of the Prometheus package
 [go.opencensus.io/exporter/prometheus](https://godoc.org/go.opencensus.io/exporter/prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Go/Stackdriver.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/go/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
 Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
@@ -25,6 +21,10 @@ Stackdriver ingests that data and generates insights via dashboards, charts, and
 integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
 OpenCensus Go has support for this exporter available through package [contrib.go.opencensus.io/exporter/stackdriver](https://godoc.org/contrib.go.opencensus.io/exporter/stackdriver)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Go/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Go/Zipkin.md
@@ -9,15 +9,15 @@ aliases: [/supported-exporters/go/zipkin]
 
 ![](/img/zipkin-logo.jpg)
 
-{{% notice note %}}
-This guide makes use of Zipkin for visualizing your data. For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
-{{% /notice %}}
-
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
 
 It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
 
 OpenCensus Go has support for this exporter available through package [go.opencensus.io/exporter/zipkin](https://godoc.org/go.opencensus.io/exporter/zipkin)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Java/Jaeger.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
-{{% notice note %}}
-This guide makes use of Jaeger for visualizing your data. For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
-{{% /notice %}}
-
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -23,6 +19,10 @@ It is used for monitoring and troubleshooting microservices-based distributed sy
 * Performance / latency optimization
 
 OpenCensus Java has support for this exporter available through package [io.opencensus.exporter.trace.jaeger](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Java/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Java/Prometheus.md
@@ -9,16 +9,16 @@ aliases: [/supported-exporters/java/prometheus]
 
 ![](/img/prometheus-logo.png)
 
-{{% notice note %}}
-This guide makes use of Prometheus for receiving and visualizing your data. For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
-{{% /notice %}}
-
 Prometheus is a monitoring system that collects metrics, by scraping
 exposed endpoints at regular intervals, evaluating rule expressions.
 It can also trigger alerts if certain conditions are met.
 
 OpenCensus Java allows exporting stats to Prometheus by means of the Prometheus package
 [io.opencensus.exporter.stats.prometheus](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Java/SignalFx.md
+++ b/content/guides/exporters/supported-exporters/Java/SignalFx.md
@@ -9,14 +9,6 @@ aliases: [/supported-exporters/java/signalfx]
 
 ![](https://opencensus.io/img/signalFx_logo.svg)
 
-{{% notice note %}}
-This guide makes use of SignalFx.
-You'll need to have:
-
-* A [SignalFx account](https://signalfx.com/)
-* The corresponding [data ingest token](https://docs.signalfx.com/en/latest/admin-guide/tokens.html)
-{{% /notice %}}
-
 SignalFx is a real-time monitoring solution for cloud and distributed applications.
 SignalFx ingests that data and offers various visualizations on charts, dashboards and service maps,
 as well as real-time anomaly detection.
@@ -24,6 +16,15 @@ as well as real-time anomaly detection.
 OpenCensus Java has support for this exporter available through the package:
 
 * Stats [io.opencensus.exporter.stats.signalfx](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-signalfx)
+
+{{% notice tip %}}
+This guide makes use of SignalFx.
+You'll need to have:
+
+* A [SignalFx account](https://signalfx.com/)
+* The corresponding [data ingest token](https://docs.signalfx.com/en/latest/admin-guide/tokens.html)
+{{% /notice %}}
+
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Java/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Java/Stackdriver.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/java/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
 Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
@@ -27,6 +23,10 @@ integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 OpenCensus Java has support for this exporter available through packages:
 * Stats [io.opencensus.exporter.stats.stackdriver](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-stackdriver)
 * Trace [io.opencensus.exporter.trace.stackdriver](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-stackdriver)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporters](#creating-the-exporters)

--- a/content/guides/exporters/supported-exporters/Python/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Python/Jaeger.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/python/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
-{{% notice note %}}
-This guide makes use of Jaeger for visualizing your data. For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
-{{% /notice %}}
-
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -23,6 +19,10 @@ It is used for monitoring and troubleshooting microservices-based distributed sy
 * Performance / latency optimization
 
 OpenCensus Python has support for this exporter available through package [opencensus.trace.exporters.jaeger_exporter](https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/trace/exporters/jaeger_exporter.py)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/exporters/supported-exporters/Python/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Python/Stackdriver.md
@@ -9,10 +9,6 @@ aliases: [/supported-exporters/python/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
 Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
@@ -26,6 +22,10 @@ integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
 OpenCensus Python has support for this exporter available through package:
 * Trace [opencensus.trace.exporters.stackdriver_exporter](https://census-instrumentation.github.io/opencensus-python/trace/api/stackdriver_exporter.html)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporters](#creating-the-exporters)

--- a/content/guides/exporters/supported-exporters/Python/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Python/Zipkin.md
@@ -9,15 +9,15 @@ aliases: [/supported-exporters/python/zipkin]
 
 ![](/img/zipkin-logo.jpg)
 
-{{% notice note %}}
-This guide makes use of Zipkin for visualizing your data. For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
-{{% /notice %}}
-
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
 
 It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
 
 OpenCensus Python has support for this exporter available through package [opencensus.trace.exporters.zipkin_exporter](https://census-instrumentation.github.io/opencensus-python/trace/api/zipkin_exporter.html)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
 
 #### Table of contents
 - [Creating the exporter](#creating-the-exporter)

--- a/content/guides/gRPC/Go.md
+++ b/content/guides/gRPC/Go.md
@@ -8,13 +8,6 @@ aliases: [/grpc/go]
 
 ![](/images/go-grpc-opencensus.png)
 
-{{% notice note %}}
-Before beginning, if you haven't already:
-
-* Setup gRPC for Go by visiting this quickstart page [https://grpc.io/docs/quickstart/go.html](https://grpc.io/docs/quickstart/go.html)
-* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
-{{% / notice %}}
-
 #### Table of contents
 - [Overview](#overview)
     - [Protobuf definition](#protobuf-definition)
@@ -56,6 +49,13 @@ Server handler|[go.opencensus.io/plugin/ocgrpc.ServerHandler](https://godoc.org/
 Client handler|[go.opencensus.io/plugin/ocgrpc.ClientHandler](https://godoc.org/go.opencensus.io/plugin/ocgrpc#ServerHandler)
 Server gRPC metrics/views|[https://godoc.org/go.opencensus.io/plugin/ocgrpc#DefaultServerViews](https://godoc.org/go.opencensus.io/plugin/ocgrpc#DefaultServerViews)
 Client gRPC metrics/views|[https://godoc.org/go.opencensus.io/plugin/ocgrpc#DefaultClientViews](https://godoc.org/go.opencensus.io/plugin/ocgrpc#DefaultClientViews)
+
+{{% notice tip %}}
+Before beginning, if you haven't already:
+
+* Setup gRPC for Go by visiting this quickstart page [https://grpc.io/docs/quickstart/go.html](https://grpc.io/docs/quickstart/go.html)
+* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
+{{% / notice %}}
 
 #### Requirements
 

--- a/content/guides/gRPC/Java.md
+++ b/content/guides/gRPC/Java.md
@@ -8,13 +8,6 @@ aliases: [/grpc/java]
 
 ![](/images/java-grpc-opencensus.png)
 
-{{% notice note %}}
-Before beginning, if you haven't already:
-
-* Setup gRPC for Java by visiting this quickstart page [https://grpc.io/docs/quickstart/java.html](https://grpc.io/docs/quickstart/java.html)
-* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
-{{% / notice %}}
-
 #### Table of contents
 - [Overview](#overview)
     - [Protobuf definition](#protobuf-definition)
@@ -33,6 +26,13 @@ Our serivce takes in a payload containing bytes and capitalizes them.
 Using OpenCensus, we can collect traces and metrics of our system and export them to the backend of our choice, to give observability to our distributed systems.
 
 grpc-Java has already been instrumented [gRPC-Core](https://github.com/grpc/grpc-java) with OpenCensus for tracing and metrics. Application users just need to add a runtime dependency on OpenCensus-Java impl, and the instrumentations should just work.
+
+{{% notice tip %}}
+Before beginning, if you haven't already:
+
+* Setup gRPC for Java by visiting this quickstart page [https://grpc.io/docs/quickstart/java.html](https://grpc.io/docs/quickstart/java.html)
+* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
+{{% / notice %}}
 
 As specified at [grpc-java on Github](https://github.com/grpc/grpc-java#download), the respective inclusions to our build systems are:
 

--- a/content/guides/gRPC/Python.md
+++ b/content/guides/gRPC/Python.md
@@ -8,13 +8,6 @@ aliases: [/grpc/python]
 
 ![](/images/python-grpc-opencensus.png)
 
-{{% notice note %}}
-Before beginning, if you haven't already:
-
-* Setup gRPC for Python by visiting this quickstart page [https://grpc.io/docs/quickstart/python.html](https://grpc.io/docs/quickstart/python.html)
-* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
-{{% / notice %}}
-
 ## Table of contents
 - [Overview](#overview)
 - [Setup](#setup)
@@ -33,6 +26,13 @@ Our service takes in a payload containing bytes and capitalizes them.
 
 Using OpenCensus, we can collect traces of our system and export them to the backend
 of our choice, to give observability to our distributed systems.
+
+{{% notice tip %}}
+Before beginning, if you haven't already:
+
+* Setup gRPC for Python by visiting this quickstart page [https://grpc.io/docs/quickstart/python.html](https://grpc.io/docs/quickstart/python.html)
+* Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
+{{% / notice %}}
 
 ## Setup
 Make sure to setup your `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Visit [here](https://cloud.google.com/docs/authentication/production) for instructions on how to do so.

--- a/content/guides/integrations/redis/Java.md
+++ b/content/guides/integrations/redis/Java.md
@@ -8,15 +8,6 @@ aliases: [/integrations/redis/java]
 
 ![](/images/java-opencensus.png)
 
-{{% notice note %}}
-This guide makes use of Redis. If you don't yet have an installation of Redis, please [Click here to get started](https://redis.io/topics/quickstart)
-{{% /notice %}}
-
-{{% notice note %}}
-This guide makes use of Stackdriver. If you haven't yet, please [Click here to get started with Stackdriver](/codelabs/stackdriver)
-{{% /notice %}}
-
-
 Some Redis clients were already instrumented to provide traces and metrics with OpenCensus
 
 Packages|Repository link
@@ -24,6 +15,7 @@ Packages|Repository link
 jedis|https://github.com/opencensus-integrations/jedis
 
 ## Table of contents
+- [prerequisites](#prerequisites)
 - [Generating the JAR](#generating-the-jar)
     - [Clone this repository](#clone-this-repository)
     - [Generate and install](#generate-and-install)
@@ -33,6 +25,19 @@ jedis|https://github.com/opencensus-integrations/jedis
     - [Running it](#running-it)
 - [Viewing your metrics](#viewing-your-metrics)
 - [Viewing your traces](#viewing-your-traces)
+
+#### Prerequisites
+
+You will need the following:
+
+* Redis
+* Google Stackdriver enabled on your project
+
+{{% notice tip %}}
+For assistance installing Redis, please [Click here to get started](https://redis.io/topics/quickstart)
+
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Generating the JAR
 

--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -5,10 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 #### Table of contents
 
 - [Requirements](#background)
@@ -39,7 +35,11 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 #### Requirements
 - Go 1.9 or above
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Installation
 

--- a/content/quickstart/go/tracing.md
+++ b/content/quickstart/go/tracing.md
@@ -5,10 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 #### Table of contents
 
 - [Requirements](#background)
@@ -32,7 +28,11 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 #### Requirements
 - Go 1.9 or above
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Installation
 

--- a/content/quickstart/java/metrics.md
+++ b/content/quickstart/java/metrics.md
@@ -5,12 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-
-It also uses Apache Maven for dependency management and building. If you haven't already installed it, please [Click here](https://maven.apache.org/install.html) for installation instructions
-{{% /notice %}}
-
 #### Table of contents
 
 - [Requirements](#requirements)
@@ -42,7 +36,13 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 - Java 8+
 - [Apache Maven](https://maven.apache.org/install.html)
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+
+For assistance setting up Apache Maven, [Click here](https://maven.apache.org/install.html) for instructions.
+{{% /notice %}}
 
 #### Installation
 ```bash

--- a/content/quickstart/java/tracing.md
+++ b/content/quickstart/java/tracing.md
@@ -5,12 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-
-It also uses Apache Maven for dependency management and building. If you haven't already installed it, please [Click here](https://maven.apache.org/install.html) for installation instructions
-{{% /notice %}}
-
 #### Table of contents
 
 - [Requirements](#background)
@@ -35,7 +29,13 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 - Java 8+
 - [Apache Maven](https://maven.apache.org/install.html)
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+
+For assistance setting up Apache Maven, [Click here](https://maven.apache.org/install.html) for instructions.
+{{% /notice %}}
 
 #### Installation
 ```bash

--- a/content/quickstart/python/metrics.md
+++ b/content/quickstart/python/metrics.md
@@ -4,10 +4,8 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-
-This tutorial is also incomplete, pending OpenCensus Python adding Metrics exporters
+{{% notice warning %}}
+This tutorial is incomplete, pending OpenCensus Python adding Metrics exporters
 {{% /notice %}}
 
 #### Table of contents
@@ -40,7 +38,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 #### Requirements
 - Python2 and above
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
 
 #### Installation
 
@@ -111,7 +109,7 @@ import opencensus.tags import tag_value as tag_value_module
 # Create the measures
 # The latency in milliseconds
 m_latency_ms = measure_module.MeasureFloat("repl/latency", "The latency in milliseconds per REPL loop", "ms")
-	
+
 # Counts the number of lines read in from standard input
 m_lines_in = measure_module.MeasureInt("repl/lines_in", "The number of lines read in", "1")
 
@@ -138,7 +136,7 @@ from opencensus.tags import tag_value as tag_value_module
 # Create the measures
 # The latency in milliseconds
 m_latency_ms = measure_module.MeasureFloat("repl/latency", "The latency in milliseconds per REPL loop", "ms")
-	
+
 # Counts the number of lines read in from standard input
 m_lines_in = measure_module.MeasureInt("repl/lines_in", "The number of lines read in", "1")
 
@@ -209,7 +207,7 @@ from opencensus.tags import tag_value as tag_value_module
 # Create the measures
 # The latency in milliseconds
 m_latency_ms = measure_module.MeasureFloat("repl/latency", "The latency in milliseconds per REPL loop", "ms")
-	
+
 # Counts the number of lines read in from standard input
 m_lines_in = measure_module.MeasureInt("repl/lines_in", "The number of lines read in", "1")
 
@@ -231,7 +229,7 @@ latency_view = view_module.View("demo/latency", "The distribution of the latenci
 		# Latency in buckets:
 		# [>=0ms, >=25ms, >=50ms, >=75ms, >=100ms, >=200ms, >=400ms, >=600ms, >=800ms, >=1s, >=2s, >=4s, >=6s]
 		aggregation_module.DistributionAggregation([0, 25, 50, 75, 100, 200, 400, 600, 800, 1000, 2000, 4000, 6000]))
-    
+
 line_count_view = view_module.View("demo/lines_in", "The number of lines from standard input",
 		[],
                 m_lines_in,

--- a/content/quickstart/python/metrics.md
+++ b/content/quickstart/python/metrics.md
@@ -40,6 +40,10 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
 
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
+
 #### Installation
 
 OpenCensus: `pip install opencensus`

--- a/content/quickstart/python/tracing.md
+++ b/content/quickstart/python/tracing.md
@@ -5,10 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-{{% notice note %}}
-This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
-{{% /notice %}}
-
 #### Table of contents
 
 - [Requirements](#background)
@@ -32,7 +28,11 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 #### Requirements
 - Python
 - Google Cloud Platform account and project
-- Google Stackdriver Tracing enabled on your project (Need help? [Click here](/codelabs/stackdriver))
+- Google Stackdriver Tracing enabled on your project
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
 
 #### Installation
 
@@ -176,7 +176,7 @@ sde = stackdriver_exporter.StackdriverExporter(
 
 def main():
     # Firstly enable the exporter
-    
+
     # In a REPL:
     # 1. Read input
     # 2. process input
@@ -226,7 +226,7 @@ sde = stackdriver_exporter.StackdriverExporter(
 
 def main():
     # Firstly enable the exporter
-    
+
     # In a REPL:
     # 1. Read input
     # 2. process input


### PR DESCRIPTION
Fixes #247 

Two changes made:
* Position of the notice
* Color of the notice

Sections that were changed:
* quickstarts
* guides/exporters/supported-exporters
* guides/grpc
* guides/integrations/redis

**Why position change?** By placing the notice either at the end of an overview or installation section, the user's eye is already slowly moving while they read thus giving them a higher chance of not glancing over the notice. In its original position at the top of the page, I believe that the user's eye is quickly moving to find the table of contents and will gloss over the notice.

**Why the color change?** This is more subjective. I think that the green and red pop out more.

Some previews:
<img width="929" alt="screen shot 2018-08-20 at 10 02 56 am" src="https://user-images.githubusercontent.com/5974764/44355861-96e2db00-a462-11e8-95e7-df96b071e87a.png">
<img width="1226" alt="screen shot 2018-08-20 at 10 18 49 am" src="https://user-images.githubusercontent.com/5974764/44355862-98140800-a462-11e8-9bcd-1618793b8ab0.png">
<img width="1217" alt="screen shot 2018-08-20 at 10 19 21 am" src="https://user-images.githubusercontent.com/5974764/44355864-99453500-a462-11e8-8069-d251fc54501a.png">
<img width="827" alt="screen shot 2018-08-20 at 9 58 55 am" src="https://user-images.githubusercontent.com/5974764/44355865-9b0ef880-a462-11e8-82de-2f3466a51ec4.png">