### PR TITLE
content: remove all vestiges of localhost:1313 absolute URLs

### DIFF
--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -29,7 +29,7 @@ class: "shadowed-image lightbox"
 In this quickstart, we’ll gleam insights from code segments and learn how to:
 
 1. Collect metrics using [OpenCensus Metrics](/core-concepts/metrics) and [Tags](/core-concepts/tags)
-2. Register and enable an exporter for a [backend](http://localhost:1313/core-concepts/exporters/#supported-backends) of our choice
+2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View the metrics on the backend of our choice
 
 #### Requirements

--- a/content/quickstart/java/metrics.md
+++ b/content/quickstart/java/metrics.md
@@ -29,7 +29,7 @@ class: "shadowed-image lightbox"
 In this quickstart, we’ll gleam insights from code segments and learn how to:
 
 1. Collect metrics using [OpenCensus Metrics](/core-concepts/metrics) and [Tags](/core-concepts/tags)
-2. Register and enable an exporter for a [backend](http://localhost:1313/core-concepts/exporters/#supported-backends) of our choice
+2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View the metrics on the backend of our choice
 
 #### Requirements

--- a/content/quickstart/java/tracing.md
+++ b/content/quickstart/java/tracing.md
@@ -22,7 +22,7 @@ class: "shadowed-image lightbox"
 In this quickstart, we’ll gleam insights from code segments and learn how to:
 
 1. Trace the code using [OpenCensus Tracing](/core-concepts/tracing)
-2. Register and enable an exporter for a [backend](http://localhost:1313/core-concepts/exporters/#supported-backends) of our choice
+2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View traces on the backend of our choice
 
 #### Requirements
@@ -380,7 +380,7 @@ private static final Tracer tracer = Tracing.getTracer();
 
 We will be tracing the execution as it flows through `readEvaluateProcessLine`, `readLine`, and finally `processLine`.
 
-To do this, we will create a [span](http://localhost:1313/core-concepts/tracing/#spans).
+To do this, we will create a [span](/core-concepts/tracing/#spans).
 
 You can create a span by inserting the following line in each of the three functions:
 ```java
@@ -709,7 +709,7 @@ public class Repl {
 
 We will do three things in our `setupOpenCensusAndStackdriverExporter` function:
 
-1. Set our [sampling rate](http://localhost:1313/core-concepts/tracing/#sampling)
+1. Set our [sampling rate](/core-concepts/tracing/#sampling)
 ```java
 TraceConfig traceConfig = Tracing.getTraceConfig();
 // For demo purposes, lets always sample.


### PR DESCRIPTION
Reported offline by Mayur Kale, a bunch of URLs linked
to `http://localhost:1313/` which is wrong. We want relative
URLs that are agnostic of host and automatically resolve
so are of the prefix `/`.