### PR TITLE
content/quickstart/python: google-cloud-{monitoring, trace} deps

### DIFF
--- a/content/quickstart/python/metrics.md
+++ b/content/quickstart/python/metrics.md
@@ -46,7 +46,7 @@ For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a
 
 #### Installation
 
-OpenCensus: `pip install opencensus`
+OpenCensus: `pip install opencensus google-cloud-monitoring`
 
 #### Brief Overview
 By the end of this tutorial, we will do these four things to obtain metrics using OpenCensus:

--- a/content/quickstart/python/tracing.md
+++ b/content/quickstart/python/tracing.md
@@ -36,7 +36,7 @@ For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a
 
 #### Installation
 
-OpenCensus: `pip install opencensus`
+OpenCensus: `pip install opencensus google-cloud-trace`
 
 #### Getting Started
 


### PR DESCRIPTION
Reported offline Mayur Kale, the Python installation code
needs to also install:
* google-cloud-monitoring for Metrics
* google-cloud-trace for Tracing

Henry Ventura also independently discovered and reported
offline then used in the gRPC for Python tutorial submission
in PR #239