### PR TITLE
content/quickstart: update Requirements links

### DIFF
--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -7,7 +7,7 @@ class: "shadowed-image lightbox"
 
 #### Table of contents
 
-- [Requirements](#background)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Brief Overview](#brief-overview)
 - [Getting started](#getting-started)

--- a/content/quickstart/go/tracing.md
+++ b/content/quickstart/go/tracing.md
@@ -7,7 +7,7 @@ class: "shadowed-image lightbox"
 
 #### Table of contents
 
-- [Requirements](#background)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
 - [Enable Tracing](#enable-tracing)

--- a/content/quickstart/java/tracing.md
+++ b/content/quickstart/java/tracing.md
@@ -7,7 +7,7 @@ class: "shadowed-image lightbox"
 
 #### Table of contents
 
-- [Requirements](#background)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
 - [Enable Tracing](#enable-tracing)

--- a/content/quickstart/python/metrics.md
+++ b/content/quickstart/python/metrics.md
@@ -10,7 +10,7 @@ This tutorial is incomplete, pending OpenCensus Python adding Metrics exporters
 
 #### Table of contents
 
-- [Requirements](#background)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Brief Overview](#brief-overview)
 - [Getting started](#getting-started)

--- a/content/quickstart/python/tracing.md
+++ b/content/quickstart/python/tracing.md
@@ -7,7 +7,7 @@ class: "shadowed-image lightbox"
 
 #### Table of contents
 
-- [Requirements](#background)
+- [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
 - [Enable Tracing](#enable-tracing)


### PR DESCRIPTION
Reported offline by Mayur Kale, most of the "Requirements"
were broken. Accidentally they had been set to "#background".
I confirmed this by
```shell
$ grep -Rn '\[Requirements' *
```
and inspecting the returned results.