### PR TITLE
content/quickstart: add missing "io" import in first snippet

### DIFF
--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -83,6 +83,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
 	"log"
 	"os"
 )


### PR DESCRIPTION
Fixes #256