### PR TITLE
Restyle Headings and Table of Contents

### DIFF
--- a/content/quickstart/java/metrics.md
+++ b/content/quickstart/java/metrics.md
@@ -5,8 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Brief Overview](#brief-overview)
@@ -32,7 +30,8 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View the metrics on the backend of our choice
 
-#### Requirements
+## Requirements
+
 - Java 8+
 - [Apache Maven](https://maven.apache.org/install.html)
 - Google Cloud Platform account and project
@@ -44,7 +43,8 @@ For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a
 For assistance setting up Apache Maven, [Click here](https://maven.apache.org/install.html) for instructions.
 {{% /notice %}}
 
-#### Installation
+
+## Installation
 We will first create our project directory, generate the `pom.xml`, and bootstrap our entry file.
 
 ```bash
@@ -160,7 +160,7 @@ To install required dependencies, run this from your project's root directory:
 mvn install
 ```
 
-#### Brief Overview
+## Brief Overview
 By the end of this tutorial, we will do these four things to obtain metrics using OpenCensus:
 
 1. Create quantitative [metrics](/core-concepts/metrics) that we will record
@@ -168,7 +168,7 @@ By the end of this tutorial, we will do these four things to obtain metrics usin
 3. Organize our metrics, similar to writing a report, in to a `View`
 4. Export our views to a backend (Stackdriver in this case)
 
-#### Getting Started
+## Getting Started
 The Repl application takes input from users, converts any lower-case letters into upper-case letters, and echoes the result back to the user, for example:
 ```bash
 > foo
@@ -201,9 +201,9 @@ You can recompile and run the application after editing it by running this comma
 mvn install
 ```
 
-#### Enable Metrics
+## Enable Metrics
 
-##### Import Packages
+### Import Packages
 To enable metrics, we’ll declare the dependencies in your `pom.xml` file. Add the following snippet of code after the `<properties>...</properties>` node.
 
 {{<tabs Snippet All>}}
@@ -366,7 +366,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Measures for Metrics
+### Create Measures for Metrics
 First, we will create the variables needed to later record our metrics. Place the following snippet on the line after `public class Repl {`:
 
 {{<tabs Snippet All>}}
@@ -460,7 +460,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Tags
+### Create Tags
 Now we will create the variable later needed to record extra text meta-data.
 
 Insert the following snippet on the line before `private static final Tagger tagger = Tags.getTagger();`:
@@ -665,7 +665,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Recording Metrics
+### Recording Metrics
 Finally, we'll hook our stat recorders in to `main`, `processLine`, and `readEvaluateProcessLine`:
 
 {{<tabs Snippet All>}}
@@ -817,11 +817,12 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Enable Views
+## Enable Views
 In order to analyze these stats, we’ll need to aggregate our data with Views.
 
+
 <a name="import-views-packages"></a>
-##### Import Packages
+### Import Packages
 
 {{<tabs Snippet All>}}
 {{<highlight java>}}
@@ -949,7 +950,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Views
+### Create Views
 Append this code snippet as our last function inside of `public class Repl`:
 
 {{<tabs Snippet All>}}
@@ -1142,7 +1143,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Register Views
+### Register Views
 We will create a function called `setupOpenCensusAndStackdriverExporter` and call it from our main function:
 
 {{<tabs Snippet All>}}
@@ -1341,9 +1342,9 @@ public class Repl {
 
 
 
-#### Exporting to Stackdriver
+## Exporting to Stackdriver
 
-##### Import Packages
+### Import Packages
 Add the following code snippet to your `<dependencies>...</dependencies>` node in `pom.xml`:
 {{<tabs Snippet All>}}
 {{<highlight xml>}}
@@ -1606,7 +1607,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Export Views
+### Export Views
 We will further expand upon `setupOpenCensusAndStackdriverExporter`:
 
 ```java
@@ -1838,7 +1839,7 @@ public class Repl {
 }
 ```
 
-#### Viewing your Metrics on Stackdriver
+## Viewing your Metrics on Stackdriver
 With the above you should now be able to navigate to the [Google Cloud Platform console](https://app.google.stackdriver.com/metrics-explorer), select your project, and view the metrics.
 
 In the query box to find metrics, type `quickstart` as a prefix:

--- a/static/css/content.css
+++ b/static/css/content.css
@@ -4,11 +4,6 @@ article section.page h1:first-of-type {
   padding: 5px;
 }
 
-h1, h2, h3, h4 {
-  font-family: "Novacento Sans Wide", "Helvetica", "Tahoma", "Geneva", "Arial", sans-serif;
-  text-transform: uppercase;
-}
-
 p {
   color: #555;
 }
@@ -40,21 +35,46 @@ article section.page h1:first-of-type {
   padding: 10px;
 }
 
+/* HEADERS */
+
+h1, h2, h3, h4, h5, h6 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
 h1, h2, h3, h4 {
   text-transform: none;
-  font-weight: 300;
 }
 
 h2 {
-  margin-top: 40px;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
-}
-
-h4, h5 {
   border-top: 1px solid #efefef;
   padding-top: 10px;
   margin-top: 30px;
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+/* HEADER SIZES */
+h3 {
+  font-size: 2rem;
+}
+
+h4 {
+  font-size: 1.8rem;
+}
+
+h5 {
+  font-size: 1.5rem;
+}
+
+h6 {
+  font-size: 1.15rem;
+}
+/* /HEADER SIZES */
+
+/* /HEADERS */
+
+article section.page ul:first-of-type ul li {
+  list-style-type: circle;
+  font-weight: lighter;
+  font-size: 14px;
 }
 
 p, ol, li, a {


### PR DESCRIPTION
Fixes #267

This PR allows us to standardize the usage of headings across all guides to create more consistency. It also makes the Table of Contents more visually digestable.

Included in this PR:

* style changes in content.css
* refactor of java metric quickstart to incorporate new style standard

If this PR is agreeable, I will follow up shortly with another PR that incorporates the new style standard across all guides.

Images: 

* [Previous Headings](https://user-images.githubusercontent.com/5974764/44432913-e7d4fb00-a558-11e8-9e18-93acaba18384.png) | [New Headings](https://user-images.githubusercontent.com/5974764/44432918-ec011880-a558-11e8-92df-fdb535e83a62.png)
* [Table of Contents](https://user-images.githubusercontent.com/5974764/44480242-9e87b880-a5f7-11e8-8f68-d648628a2e70.png)
* [Section Title](https://user-images.githubusercontent.com/5974764/44480283-b95a2d00-a5f7-11e8-8f57-eb32cb46dd1c.png)
* [Subsection Titles](https://user-images.githubusercontent.com/5974764/44480310-c840df80-a5f7-11e8-8052-cfca74cc35d1.png)

Style Changes:

* Lessens the presence of ToC subsection titles
* Standardizes font across all heading elements (`h1` to `h6`)
* Reviewed font size of all heading elements and set new font sizes for our needs
* Made it so only `h2` has a top border, which is to be used as a section title in guides

HTML changes (only applied to Java Metrics Quickstart):

* Removed "Table of Contents" heading, is redundant and adds too much visual noise
* All section titles are `h2`
* All subsection titles are `h3`