### PR TITLE
Standardize guides

### DIFF
--- a/content/guides/exporters/custom-exporter/Go/Metrics.md
+++ b/content/guides/exporters/custom-exporter/Go/Metrics.md
@@ -5,14 +5,13 @@ weight: 3
 aliases: [/custom_exporter/go/metrics]
 ---
 
-### Table of contents
 - [Introduction](#introduction)
 - [Implementation](#implementation)
 - [Runnable example](#runnable-example)
 - [Notes](#notes)
 - [References](#references)
 
-#### Introduction
+## Introduction
 A metrics/stats exporter must conform to the interface [stats/view.Exporter](https://godoc.org/go.opencensus.io/stats/view#Exporter) which for purposes of brevity is:
 
 ```go
@@ -25,7 +24,7 @@ type Exporter interface {
 
 whose sole method `ExportView` is the one in which you'll process and translate [View Data](https://godoc.org/go.opencensus.io/stats/view#Data) into the data that your metrics backend accepts.
 
-#### Implementation
+## Implementation
 
 For example, let's create a custom metrics/stats exporter that will print view data to standard output.
 
@@ -57,7 +56,7 @@ and then afterwards we must ensure that we invoke `view.RegisterExporter` with a
 view.RegisterExporter(new(customMetricsExporter))
 ```
 
-#### Runnable example
+## Runnable example
 and now to test it out as we would in a typically linked program
 
 ```go
@@ -145,14 +144,14 @@ vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKe
 StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.498909 -0700 PDT
 ```
 
-#### Notes
+## Notes
 
 * Please remember to invoke [view.RegisterExporter](https://godoc.org/go.opencensus.io/stats/view#RegisterExporter) so that your exporter
 will receive exported view data.
 
 * To change the frequency at which your view data will be exported, please see [view.SetReportingPeriod](https://godoc.org/go.opencensus.io/stats/view#SetReportingPeriod)
 
-#### References
+## References
 
 Name|Link
 ---|---

--- a/content/guides/exporters/custom-exporter/Go/Trace.md
+++ b/content/guides/exporters/custom-exporter/Go/Trace.md
@@ -5,14 +5,13 @@ weight: 3
 aliases: [/custom_exporter/go/trace]
 ---
 
-### Table of contents
 - [Introduction](#introduction)
 - [Implementation](#implementation)
 - [Runnable example](#runnable-example)
 - [Notes](#notes)
 - [References](#references)
 
-#### Introduction
+## Introduction
 A trace exporter must conform to the interface [trace.Exporter](https://godoc.org/go.opencensus.io/trace#Exporter)
 
 which for purposes of brevity is:
@@ -27,7 +26,7 @@ type Exporter interface {
 
 whose sole method `ExportSpan` is the one in which you'll process and translate [Span Data](https://godoc.org/go.opencensus.io/trace#SpanData) into the data that your trace backend accepts.
 
-#### Implementation
+## Implementation
 
 For example, let's make a custom trace exporter that will print span data to standard output.
 
@@ -55,7 +54,7 @@ and then afterwards we must ensure that we invoke `trace.RegisterExporter` with 
 trace.RegisterExporter(new(customTraceExporter))
 ```
 
-#### Runnable example
+## Runnable example
 and now to test it out as we would in a typically linked program
 
 ```go
@@ -138,7 +137,7 @@ EndTime: 2018-08-07 23:56:29.035817031 -0700 PDT m=+0.048155109
 Annotations: [{Time:2018-08-07 23:56:29.035812 -0700 PDT m=+0.048150248 Message:Invoked it Attributes:map[invocations:1]}]
 ```
 
-#### Notes
+## Notes
 
 * Please remember to invoke [trace.RegisterExporter](https://godoc.org/go.opencensus.io/trace#RegisterExporter) so that your exporter
 will receive exported spans.
@@ -147,7 +146,7 @@ will receive exported spans.
 * If you need to do heavy processing in the `ExportSpan` method, please do it in a goroutine because ExportSpan is invoked
 on the fast path
 
-#### References
+## References
 
 Name|Link
 ---|---

--- a/content/guides/exporters/custom-exporter/Java/Trace.md
+++ b/content/guides/exporters/custom-exporter/Java/Trace.md
@@ -5,14 +5,13 @@ weight: 3
 aliases: [/custom_exporter/java/trace]
 ---
 
-### Table of contents
 - [Introduction](#introduction)
 - [Implementation](#implementation)
 - [Runnable example](#runnable-example)
 - [Notes](#notes)
 - [References](#references)
 
-#### Introduction
+## Introduction
 
 A trace exporter must extend the abstract class [SpanExporter.Handler](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanExporter.Handler.html) implementing the `export` method
 
@@ -34,7 +33,7 @@ After an exporter is created, it must be registered with [SpanExporter.registerH
 SpanExporter.registerHandler(nameOfTheExporter, anInstanceOfTheExporter);
 ```
 
-#### Implementation
+## Implementation
 
 For example, let's make a custom trace exporter that will print span data to standard output.
 
@@ -70,7 +69,7 @@ public class CustomTraceExporter extends SpanExporter.Handler {
 }
 ```
 
-#### Runnable example
+## Runnable example
 
 With the previous implementation, here is a fully runnable example, that we'll run using Maven.
 
@@ -267,13 +266,13 @@ Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=15337689
 
 ```
 
-#### Notes
+## Notes
 
 * Please remember to invoke [SpanExporter.registerHandler](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanExporter.html#registerHandler-java.lang.String-io.opencensus.trace.export.SpanExporter.Handler-) for your created Trace exporter lest it won't receive exported span data
 
 * Your exporter's `export` method will receive exported span data only for spans that have been ended
 
-#### References
+## References
 
 Name|Link
 ---|---

--- a/content/guides/exporters/supported-exporters/Go/DataDog.md
+++ b/content/guides/exporters/supported-exporters/Go/DataDog.md
@@ -9,16 +9,18 @@ aliases: [/supported-exporters/go/datadog]
 
 ![](https://datadog-prod.imgix.net/img/press-logo-v-purpleb.png)
 
-[Datadog](https://www.datadoghq.com/) is a real-time monitoring system that supports distributed tracing and monitoring.
-
-Its OpenCensus Go exporter is available at [https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog](https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog)
-
-#### Table of contents
+- [Introduction](#introduction)
 - [Creating the exporter](#creating-the-exporter)
 - [Viewing your metrics](#viewing-your-metrics)
 - [Viewing your traces](#viewing-your-traces)
 
-##### Creating the exporter
+## Introduction
+[Datadog](https://www.datadoghq.com/) is a real-time monitoring system that supports distributed tracing and monitoring.
+
+Its OpenCensus Go exporter is available at [https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog](https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog)
+
+
+## Creating the exporter
 
 To create the exporter, we'll need:
 * Datadog credentials which you can get from [Here](https://docs.datadoghq.com/getting_started/)
@@ -113,8 +115,8 @@ func main() {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://docs.datadoghq.com/graphing/](https://docs.datadoghq.com/graphing/)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://docs.datadoghq.com/tracing/](https://docs.datadoghq.com/tracing/)

--- a/content/guides/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Go/Jaeger.md
@@ -9,6 +9,12 @@ aliases: [/supported-exporters/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -24,12 +30,8 @@ OpenCensus Go has support for this exporter available through package [go.opence
 For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
 
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
@@ -63,8 +65,8 @@ func main() {
 }
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit the Jaeger UI endpoint [http://localhost:6831](http://localhost:6831)
 
-#### Project link
+## Project link
 You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/guides/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Go/Prometheus.md
@@ -9,6 +9,13 @@ aliases: [/supported-exporters/go/prometheus]
 
 ![](/img/prometheus-logo.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Running Prometheus](#running-prometheus)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Project link](#project-link)
+
+## Introduction
 Prometheus is a monitoring system that collects metrics, by scraping
 exposed endpoints at regular intervals, evaluating rule expressions.
 It can also trigger alerts if certain conditions are met.
@@ -20,13 +27,8 @@ OpenCensus Go allows exporting stats to Prometheus by means of the Prometheus pa
 For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Running Prometheus](#running-prometheus)
-- [Viewing your metrics](#viewing-your-metrics)
-- [Project link](#project-link)
 
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Import and use the Prometheus exporter package
@@ -92,14 +94,14 @@ scrape_configs:
       - targets: ['localhost:8888']
 ```
 
-##### Running Prometheus
+## Running Prometheus
 And then run Prometheus with your configuration
 ```shell
 prometheus --config.file=prometheus.yaml
 ```
 
-##### Viewing your metrics
+## Viewing your metrics
 Please visit [http://localhost:9090](http://localhost:9090)
 
-#### Project link
+## Project link
 You can find out more about the Prometheus project at [https://prometheus.io/](https://prometheus.io/)

--- a/content/guides/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Go/Stackdriver.md
@@ -9,16 +9,22 @@ aliases: [/supported-exporters/go/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
 Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
 and can capture traces from all of your VMs, containers, or Google App Engine projects.
 
 Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
-Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation,
-and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
-Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by
-integrating with Slack, PagerDuty, HipChat, Campfire, and more.
+Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+
+Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
 OpenCensus Go has support for this exporter available through package [contrib.go.opencensus.io/exporter/stackdriver](https://godoc.org/contrib.go.opencensus.io/exporter/stackdriver)
 
@@ -26,12 +32,7 @@ OpenCensus Go has support for this exporter available through package [contrib.g
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your metrics](#viewing-your-metrics)
-- [Viewing your traces](#viewing-your-traces)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Have a GCP Project ID
@@ -136,8 +137,8 @@ func main() {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/exporters/supported-exporters/Go/XRay.md
+++ b/content/guides/exporters/supported-exporters/Go/XRay.md
@@ -9,21 +9,21 @@ aliases: [/supported-exporters/go/xray]
 
 ![](https://d1.awsstatic.com/product-marketing/X-Ray/x-ray_web-app_diagram_light.21c38e4500dca09b3c8ca4cf87f896f7bbfb8a3b.png)
 
-AWS X-Ray is a distributed trace collection and analysis system from Amazon Web Services.
-
-Its support is available by means of the X-Ray package [https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws](https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws)
-
-#### Table of contents
+- [Introduction](#introduction)
 - [Requirements](#requirements)
 - [Creating the exporter](#creating-the-exporter)
 - [Viewing your traces](#viewing-your-traces)
 
+## Introduction
+AWS X-Ray is a distributed trace collection and analysis system from Amazon Web Services.
 
-##### Requirements
+Its support is available by means of the X-Ray package [https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws](https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws)
+
+## Requirements
 You'll need to have an AWS Developer account, if you haven't yet, please visit
 In case you haven't yet enabled AWS X-Ray, please visit [https://console.aws.amazon.com/xray/home](https://console.aws.amazon.com/xray/home)
 
-##### Creating the exporter
+## Creating the exporter
 
 This is possible by importing
 
@@ -61,5 +61,5 @@ func main() {
 {{</highlight>}}
 
 
-##### Viewing your traces
+## Viewing your traces
 Please visit [https://console.aws.amazon.com/xray/home](https://console.aws.amazon.com/xray/home)

--- a/content/guides/exporters/supported-exporters/Go/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Go/Zipkin.md
@@ -9,6 +9,12 @@ aliases: [/supported-exporters/go/zipkin]
 
 ![](/img/zipkin-logo.jpg)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
 
 It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
@@ -19,12 +25,7 @@ OpenCensus Go has support for this exporter available through package [go.opence
 For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
@@ -61,8 +62,8 @@ func main() {
 }
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
 
-#### Project link
+## Project link
 You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/guides/exporters/supported-exporters/Java/Instana.md
+++ b/content/guides/exporters/supported-exporters/Java/Instana.md
@@ -9,6 +9,11 @@ aliases: [/supported-exporters/instana]
 
 ![](/images/instana.png)
 
+- [Introduction](#introduction)
+- [Creating the exporters](#creating-the-exporters)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
 Instant provides AI Powered Application and Infrastructure Monitoring, allowing you to
 deliver Faster With Confidence, and automatic Analysis and Optimization.
 
@@ -16,19 +21,14 @@ OpenCensus Java has support for this exporter available through package [io.open
 
 More information can be found at the [Instana website](https://www.instana.com/)
 
-#### Table of contents
-- [Creating the exporters](#creating-the-exporters)
-- [Viewing your traces](#viewing-your-traces)
-
-##### Creating the trace exporter
+## Creating the trace exporter
 To create the trace exporter, you'll need to:
 
 * Have Instana credentials
 * Use Maven setup your pom.xml file
 * Create the exporter in code
 
-##### pom.xml
-
+`pom.xml`
 ```xml
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -56,7 +56,7 @@ To create the trace exporter, you'll need to:
     </dependencies>
 ```
 
-##### Creating the exporter in code
+## Creating the exporter in code
 
 {{<highlight java>}}
 package io.opencensus.tutorial.instana;

--- a/content/guides/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Java/Jaeger.md
@@ -9,6 +9,12 @@ aliases: [/supported-exporters/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -24,19 +30,13 @@ OpenCensus Java has support for this exporter available through package [io.open
 For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
 * Have the Jaeger endpoint available to receive traces
 
-#### pom.xml
-If using Maven, add these to your pom.xml file
+If using Maven, add these to your `pom.xml` file
 ```xml
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,8 +75,8 @@ public class JaegerTutorial {
 }
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit the Jaeger UI endpoint [http://localhost:6831](http://localhost:6831)
 
-#### Project link
+## Project link
 You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/guides/exporters/supported-exporters/Java/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Java/Prometheus.md
@@ -9,6 +9,13 @@ aliases: [/supported-exporters/java/prometheus]
 
 ![](/img/prometheus-logo.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Running Prometheus](#running-prometheus)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Project link](#project-link)
+
+## Introduction
 Prometheus is a monitoring system that collects metrics, by scraping
 exposed endpoints at regular intervals, evaluating rule expressions.
 It can also trigger alerts if certain conditions are met.
@@ -20,13 +27,7 @@ OpenCensus Java allows exporting stats to Prometheus by means of the Prometheus 
 For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Running Prometheus](#running-prometheus)
-- [Viewing your metrics](#viewing-your-metrics)
-- [Project link](#project-link)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Import and use the Prometheus exporter package
@@ -34,10 +35,7 @@ To create the exporter, we'll need to:
 * Expose a port on which we shall run a `/metrics` endpoint
 * With the defined port, we'll need a Promethus configuration file so that Prometheus can scrape from this endpoint
 
-
-#### pom.xml
-
-Add this to your pom.xml file:
+Add this to your `pom.xml` file:
 
 ```xml
     <properties>
@@ -109,14 +107,14 @@ scrape_configs:
       - targets: ['localhost:8888']
 ```
 
-##### Running Prometheus
+## Running Prometheus
 And then run Prometheus with your configuration
 ```shell
 prometheus --config.file=prometheus.yaml
 ```
 
-##### Viewing your metrics
+## Viewing your metrics
 Please visit [http://localhost:9090](http://localhost:9090)
 
-#### Project link
+## Project link
 You can find out more about the Prometheus project at [https://prometheus.io/](https://prometheus.io/)

--- a/content/guides/exporters/supported-exporters/Java/SignalFx.md
+++ b/content/guides/exporters/supported-exporters/Java/SignalFx.md
@@ -9,6 +9,10 @@ aliases: [/supported-exporters/java/signalfx]
 
 ![](https://opencensus.io/img/signalFx_logo.svg)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
 SignalFx is a real-time monitoring solution for cloud and distributed applications.
 SignalFx ingests that data and offers various visualizations on charts, dashboards and service maps,
 as well as real-time anomaly detection.
@@ -25,11 +29,10 @@ You'll need to have:
 * The corresponding [data ingest token](https://docs.signalfx.com/en/latest/admin-guide/tokens.html)
 {{% /notice %}}
 
+## Creating the exporter
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
 
-##### pom.xml
+Insert the following snippet in your `pom.xml`:
 
 ```xml
 <properties>
@@ -57,7 +60,7 @@ You'll need to have:
 </dependencies>
 ```
 
-#### Creating the exporter in code
+Instrument your application code with the following snippet:
 
 {{<highlight java>}}
 package io.opencensus.tutorial.signalfx;

--- a/content/guides/exporters/supported-exporters/Java/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Java/Stackdriver.md
@@ -9,16 +9,24 @@ aliases: [/supported-exporters/java/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
+- [Introduction](#introduction)
+- [Creating the exporters](#creating-the-exporters)
+    - [Import Packages](#import-packages)
+    - [Instrument Metrics and Traces](#instrument-metrics-and-traces)
+    - [All Exporters Combined](#all-exporters-combined)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
-Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
-and can capture traces from all of your VMs, containers, or Google App Engine projects.
+Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations, and can capture traces from all of your VMs, containers, or Google App Engine projects.
 
 Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
-Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation,
-and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
-Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by
-integrating with Slack, PagerDuty, HipChat, Campfire, and more.
+Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+
+Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
 OpenCensus Java has support for this exporter available through packages:
 * Stats [io.opencensus.exporter.stats.stackdriver](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-stackdriver)
@@ -28,12 +36,7 @@ OpenCensus Java has support for this exporter available through packages:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporters](#creating-the-exporters)
-- [Viewing your metrics](#viewing-your-metrics)
-- [Viewing your traces](#viewing-your-traces)
-
-##### Creating the exporters
+## Creating the exporters
 To create the exporters, you'll need to:
 
 * Have a GCP Project ID
@@ -41,8 +44,8 @@ To create the exporters, you'll need to:
 * Use Maven setup your pom.xml file
 * Create the exporters in code
 
-##### pom.xml
-
+### Import Packages
+Insert the following snippet in your `pom.xml`:
 ```xml
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -75,9 +78,12 @@ To create the exporters, you'll need to:
         </dependency>
     </dependencies>
 ```
+### Instrument Metrics and Traces
+Instrument your code with the following snippets:
 
-##### Creating the exporters in code
-* To enable each of the respective APIs, please click on the respective tabs and then on "ALL" at the end
+{{% notice tip %}}
+To enable each of the respective APIs, please click on the respective tabs and then refer to [the final section](http://localhost:1313/guides/exporters/supported-exporters/java/stackdriver/#all-exporters-combined).
+{{% /notice %}}
 
 {{<tabs Tracing Metrics>}}
 {{<highlight java>}}
@@ -102,8 +108,10 @@ StackdriverStatsExporter.createAndRegister(
 {{</tabs>}}
 
 
-##### All exporters combined
-* Finally, combining tracing and stats exporters together, we should now have
+### All exporters combined
+Finally, we will combine tracing and stats exporters together.
+
+Our final code snippet is the following:
 
 {{<highlight java>}}
 package io.opencensus.tutorial.stackdriver;

--- a/content/guides/exporters/supported-exporters/Java/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Java/Zipkin.md
@@ -9,29 +9,29 @@ aliases: [/supported-exporters/java/zipkin]
 
 ![](/img/zipkin-logo.jpg)
 
-{{% notice note %}}
-This guide makes use of Zipkin for visualizing your data. For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
-{{% /notice %}}
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
 
+## Introduction
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
 
 It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
 
 OpenCensus Java has support for this exporter available through package [io.opencensus.exporter.trace.zipkin](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-zipkin)
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
+{{% notice note %}}
+This guide makes use of Zipkin for visualizing your data. For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
 
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
 * Have the Zipkin endpoint available to receive traces
 
-#### pom.xml
-If using Maven, add these to your pom.xml file
+If using Maven, add these to your `pom.xml` file
 ```xml
 <properties>
   <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -58,6 +58,8 @@ If using Maven, add these to your pom.xml file
 </dependencies>
 ```
 
+Instrument your code with the following snippet:
+
 {{<highlight java>}}
 package io.opencensus.tutorial.zipkin;
 
@@ -70,8 +72,8 @@ public class ZipkinTutorial {
 }
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
 
-#### Project link
+## Project link
 You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/guides/exporters/supported-exporters/Python/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Python/Jaeger.md
@@ -9,6 +9,12 @@ aliases: [/supported-exporters/python/jaeger]
 
 ![](https://www.jaegertracing.io/img/jaeger-logo.png)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
 Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
 It is used for monitoring and troubleshooting microservices-based distributed systems, including:
 
@@ -24,12 +30,7 @@ OpenCensus Python has support for this exporter available through package [openc
 For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
@@ -56,9 +57,8 @@ if __name__ == "__main__":
     main()
 {{</highlight>}}
 
-
-#### Viewing your traces
+## Viewing your traces
 Please visit the Jaeger UI endpoint [http://localhost:6831](http://localhost:6831)
 
-#### Project link
+## Project link
 You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/guides/exporters/supported-exporters/Python/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Python/Stackdriver.md
@@ -9,14 +9,19 @@ aliases: [/supported-exporters/python/stackdriver]
 
 ![](/images/logo_gcp_vertical_rgb.png)
 
+- [Introduction](#introduction)
+- [Creating the exporters](#creating-the-exporters)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
 Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
 You can track how requests propagate through your application and receive detailed near real-time performance insights.
-Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
-and can capture traces from all of your VMs, containers, or Google App Engine projects.
+Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations, and can capture traces from all of your VMs, containers, or Google App Engine projects.
 
 Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
-Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation,
-and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+
 Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by
 integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
@@ -27,18 +32,15 @@ OpenCensus Python has support for this exporter available through package:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporters](#creating-the-exporters)
-- [Viewing your traces](#viewing-your-traces)
-
-##### Creating the exporters
+## Creating the exporters
 To create the exporters, you'll need to:
 
 * Have a GCP Project ID
 * Have already enabled Stackdriver Tracing and Metrics, if not, please visit the [Code lab](/codelabs/stackdriver)
 * Create the exporters in code
 
-##### Creating the exporter in code
+Instrument your code with the following snippet:
+
 {{<highlight python>}}
 #!/usr/bin/env python
 
@@ -62,8 +64,8 @@ if __name__ == "__main__":
     main()
 {{</highlight>}}
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/exporters/supported-exporters/Python/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Python/Zipkin.md
@@ -9,6 +9,12 @@ aliases: [/supported-exporters/python/zipkin]
 
 ![](/img/zipkin-logo.jpg)
 
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
 Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
 
 It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
@@ -19,12 +25,7 @@ OpenCensus Python has support for this exporter available through package [openc
 For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
 {{% /notice %}}
 
-#### Table of contents
-- [Creating the exporter](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
-- [Project link](#project-link)
-
-##### Creating the exporter
+## Creating the exporter
 To create the exporter, we'll need to:
 
 * Create an exporter in code
@@ -51,8 +52,8 @@ if __name__ == "__main__":
     main()
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
 
-#### Project link
+## Project link
 You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/guides/gRPC/Java.md
+++ b/content/guides/gRPC/Java.md
@@ -8,10 +8,12 @@ aliases: [/grpc/java]
 
 ![](/images/java-grpc-opencensus.png)
 
-#### Table of contents
 - [Overview](#overview)
+- [Creating our gRPC Service](#creating-our-grpc-service)
+    - [Import Packages](#import-packages)
     - [Protobuf definition](#protobuf-definition)
-    - [Generate the service](#generate-the-service)
+    - [Service implementation](#service-implementation)
+    - [Client implementation](#client-implementation)
 - [Instrumentation](#instrumentation)
     - [Instrumenting the server](#instrumenting-the-server)
     - [Instrumenting the client](#instrumenting-the-client)
@@ -19,7 +21,7 @@ aliases: [/grpc/java]
 - [Examining metrics](#examining-metrics)
 - [Notes](#notes)
 
-#### Overview
+## Overview
 
 Our serivce takes in a payload containing bytes and capitalizes them.
 
@@ -34,6 +36,9 @@ Before beginning, if you haven't already:
 * Setup [Stackdriver Tracing and Monitoring](/codelabs/stackdriver/)
 {{% / notice %}}
 
+## Creating our gRPC Service
+
+### Import Packages
 As specified at [grpc-java on Github](https://github.com/grpc/grpc-java#download), the respective inclusions to our build systems are:
 
 {{<tabs Maven Non-Android_Gradle Android-Gradle>}}
@@ -68,7 +73,7 @@ compile 'io.grpc:grpc-stub:1.14.0'
 {{</highlight>}}
 {{</tabs>}}
 
-#### Protobuf definition
+### Protobuf definition
 
 Make a directory structure `src/main/proto`
 
@@ -95,7 +100,7 @@ service Fetch {
 {{</highlight>}}
 
 
-#### Generate the service
+### Service implementation
 
 The source code below and the pom.xml file will be used to generate the service
 Please place the server code in file `src/main/java/io/octutorials/ocgrpc/TutorialServer.java`.
@@ -287,7 +292,7 @@ which will give such output
 
 ![](/images/java-grpc-server-plain.png)
 
-##### Client
+### Client implementation
 
 The client talks to the server via a gRPC channel, sending in bytes and getting back the output capitalized.
 
@@ -360,11 +365,11 @@ public class TutorialClient {
 which will give you such output after you've typed in
 ![](/images/ocgrpc-java-client.png)
 
-#### Instrumentation
+## Instrumentation
 
 To gain insights to our service, we'll add trace and metrics instrumentation as follows
 
-##### Instrumenting the server
+### Instrumenting the server
 
 
 We'll instrument the server by tracing as well as gRPC metrics using OpenCensus with imports such as:
@@ -764,7 +769,7 @@ public class TutorialServer {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Instrumenting the client
+### Instrumenting the client
 
 We'll instrument the client too by tracing as well as gRPC metrics using OpenCensus with imports such as:
 
@@ -1003,7 +1008,7 @@ mvn exec:java -Dexec.mainClass=io.octutorials.ocgrpc.TutorialServer
 mvn exec:java -Dexec.mainClass=io.octutorials.ocgrpc.TutorialClient
 ```
 
-#### Examining traces
+## Examining traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)
 
 which will give visuals such as:
@@ -1012,7 +1017,7 @@ which will give visuals such as:
 
 ![Single trace details](/images/ocgrpc-tutorial-java-trace-details.png)
 
-#### Examining metrics
+## Examining metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
 which will give visuals such as:
@@ -1028,7 +1033,7 @@ which will give visuals such as:
 ![](/images/ocgrpc-tutorial-java-server-latency-cumulative.png)
 ![](/images/ocgrpc-tutorial-java-server-latency-p99th.png)
 
-#### References
+## References
 
 Notes|Link
 ---|---

--- a/content/guides/gRPC/Python.md
+++ b/content/guides/gRPC/Python.md
@@ -8,7 +8,6 @@ aliases: [/grpc/python]
 
 ![](/images/python-grpc-opencensus.png)
 
-## Table of contents
 - [Overview](#overview)
 - [Setup](#setup)
     - [Installation](#installation)
@@ -37,7 +36,7 @@ Before beginning, if you haven't already:
 ## Setup
 Make sure to setup your `GOOGLE_APPLICATION_CREDENTIALS` environment variable. Visit [here](https://cloud.google.com/docs/authentication/production) for instructions on how to do so.
 
-##### Installation
+### Installation
 This walkthrough will be using [Python 3](https://www.python.org/download/releases/3.0/).
 
 Install the required modules by running this command in your terminal:
@@ -62,7 +61,7 @@ Our working directory will now look like this:
 ./proto/defs.proto
 ```
 
-##### Protobuf Definition
+### Protobuf Definition
 Copy and paste the following code inside of `./proto/defs.proto`:
 
 ```proto
@@ -100,7 +99,7 @@ This will create two new files. Your working directory will be:
 ./proto/defs.proto
 ```
 
-##### Generate the Client
+### Generate the Client
 Copy and paste the following code inside of `./capitalizeClient.py`:
 
 ```py
@@ -122,7 +121,7 @@ if __name__ == '__main__':
     main()
 ```
 
-##### Generate the Service
+### Generate the Service
 Copy and paste the following code inside of `./capitalizeServer.py`:
 
 ```py
@@ -156,7 +155,7 @@ if __name__ == '__main__':
     main()
 ```
 
-##### Run the Application
+### Run the Application
 Let's now run two of our python files at once. You may need to open a second terminal tab.
 
 In one terminal tab, run `python3 capitalizeServer.py`.
@@ -169,7 +168,7 @@ Try typing in some text and hitting enter in the tab running `capitalizeClient.p
 
 ## Instrumentation
 
-##### Tracing
+### Tracing
 Open `./capitalizeServer.py`.
 
 First let's import the required packages:
@@ -334,7 +333,7 @@ if __name__ == '__main__':
 {{</highlight>}}
 {{</tabs>}}
 
-##### Exporting
+### Exporting
 Import the required packages:
 
 {{<tabs Snippet All>}}

--- a/content/guides/integrations/caddy.md
+++ b/content/guides/integrations/caddy.md
@@ -8,8 +8,6 @@ aliases: [/integrations/caddy]
 
 ![caddy logo](/img/caddyserver-logo.png)
 
-#### Table of contents
-
 - [Background](#background)
 - [Enabling Observability](#enabling-observability)
     - [Git checkout](#git-checkout)
@@ -17,8 +15,7 @@ aliases: [/integrations/caddy]
     - [Variables Table](#variables-table)
     - [Examples](#examples)
 
-#### Background
-
+## Background
 Caddy is a modern server that is deployable for modern web services.
 With the increasing complexity and style of deployment of many web services,
 examining the behavior of the entire system quickly becomes very complex,
@@ -65,14 +62,12 @@ for your teams, the project maintainers either nor should they require sophistic
 and specialized distributed systems and observability knowledge, nor should it require
 sophisicated infrastructure deployments.
 
-#### Enabling Observability
-
+## Enabling Observability
 ```shell
 caddy -observability "<sampler_rate>;exporter1:[config1Key=config1Value:config2Key=config2Value...][,]exporter2...]"
 ```
 
-##### Git checkout
-
+### Git checkout
 You can enable observability by checking out the instrumented branch of caddy
 ```shell
 go get github.com/mholt/caddy/caddy
@@ -80,8 +75,7 @@ cd $GOPATH/src/github.com/mholt/caddy
 git add orijtech git@github.com:orijtech/caddy.git && git fetch orijtech && git checkout instrument-with-opencensus && go get ./caddy
 ```
 
-##### Syntax
-
+### Syntax
 ```xml
 observability   := SamplerRate;Exporters
 SamplerRate     := float64 value
@@ -93,8 +87,7 @@ KeyToken        := string
 ValueToken      := string
 ```
 
-##### Variables Table
-
+### Variables Table
 Exporter Name|Key|Type|Notes|Example
 ---|---|---|---|---
 aws-xray|AWS_REGION|String|The region that your project is located in|`AWS_REGION=us-west-2`
@@ -112,8 +105,7 @@ zipkin|local|URL|The URL of the local endpoint|`caddy -observability "zipkin:loc
 zipkin|reporter|URL|The URL of the reporter endpoint|`caddy -observability "zipkin:reporter=http://localhost:9411/api/v2/spans"`
 zipkin|service-name|string|The name of your service|`caddy -observability "service-name=server"`
 
-##### Examples
-
+### Examples
 * Comprehensive example running with all the environment variables too
 
 ```shell

--- a/content/guides/integrations/google_cloud_bigtable/Go/_index.md
+++ b/content/guides/integrations/google_cloud_bigtable/Go/_index.md
@@ -9,7 +9,26 @@ aliases: [/integrations/google_cloud_bigtable/go]
 
 ![](/images/gopher.png)
 
-For more information, you can read about it here and get started [Bigtable docs](https://cloud.google.com/bigtable/docs).
+- [Introduction](#introduction)
+- [Packages to import](#packages-to-import)
+- [Technical detour](#technical-detour)
+- [Enable Metric Reporting](#enable-metric-reporting)
+    - [Register client metric views](#register-client-metric-views)
+    - [Register server metric views](#register-server-metric-views)
+    - [Exporting traces and metrics](#exporting traces and metrics)
+    - [End to end code sample](#end-to-end-code-sample)
+- [Enable tracing](#enable-tracing)
+- [End to end code sample](#end-to-end-code-sample)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Cloud Bigtable (cbt) is a petabyte-scale, fully managed NoSQL database service for large analytical and operational workloads.
+For more information you can read about it here and get started [Bigtable docs](https://godoc.org/cloud.google.com/go/bigtable/)
+
+Cloud Bigtable's Go package was already instrumented for Tracing with OpenCensus.
+
+For more information, visit the [Bigtable docs](https://cloud.google.com/bigtable/docs).
 
 {{% notice note %}}
 This guide makes use of a couple of APIs
@@ -20,21 +39,7 @@ Bigtable how-to-guides|[Google Cloud Platform Bigtable how-to-guides](https://cl
 Stackdriver|[Stackdriver codelab](/codelabs/stackdriver/)
 {{% /notice %}}
 
-Cloud Bigtable (cbt) is a petabyte-scale, fully managed NoSQL database service for large analytical and operational workloads.
-For more information you can read about it here and get started [Bigtable docs](https://godoc.org/cloud.google.com/go/bigtable/)
-
-Cloud Bigtable's Go package was already instrumented for:
-
-* Tracing with OpenCensus
-
-## Table of contents
-- [Packages to import](#packages-to-import)
-- [Technical detour](#technical-detour)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Viewing your traces](#viewing-your-traces)
-
-#### Packages to import
+## Packages to import
 
 For tracing and metrics on Bigtable, we'll import a couple of packages
 
@@ -51,12 +56,12 @@ import (
 )
 {{</highlight>}}
 
-#### Technical detour
+## Technical detour
 
 Because GCS uses HTTP to connect to Google's backend, we'll need to enable metrics and tracing using a custom client
 for Bigtable operations. The custom client will have an `ochttp` enabled transport and then the rest is simple
 
-#### Enable metric reporting
+## Enable metric reporting
 
 To enable metric reporting/exporting, we need to enable a metrics exporter, but before that we'll need
 to register and enable the views that match the HTTP metrics to collect. For a complete list of the available views
@@ -64,25 +69,25 @@ available please visit [https://godoc.org/go.opencensus.io/plugin/ochttp](https:
 
 However, for now we'll split them into client and server views
 
-##### Register client metric views
+### Register client metric views
 {{<highlight go>}}
 if err := view.Register(ochttp.DefaultClientViews...); err != nil {
     log.Fatalf("Failed to register HTTP client views: %v", err)
 }
 {{</highlight>}}
 
-##### Register server metric views
+### Register server metric views
 {{<highlight go>}}
 if err := view.Register(ochttp.DefaultServerViews...); err != nil {
     log.Fatalf("Failed to register HTTP server views: %v", err)
 }
 {{</highlight>}}
 
-##### Exporting traces and metrics
-The last step is to enable trace and metric exporting. For that we'll use say [Stackdriver Exporter](/supported-exporters/go/stackdriver) or
-any of the  [Go exporters](/supported-exporters/go/)
+### Exporting traces and metrics
+The last step is to enable trace and metric exporting. For that we'll use [Stackdriver Exporter](/supported-exporters/go/stackdriver) or
+any of the [Go exporters](/supported-exporters/go/)
 
-##### End to end code sample
+### End to end code sample
 
 With all the steps combined, we'll finally have this code snippet, adapted from [Bigtable Go helloworld](https://cloud.google.com/bigtable/docs/samples-go-hello/)
 
@@ -246,9 +251,9 @@ func sliceContains(list []string, target string) bool {
 }
 ```
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)
 ![](/images/cloud_bigtable_trace.png)

--- a/content/guides/integrations/google_cloud_bigtable/Java/_index.md
+++ b/content/guides/integrations/google_cloud_bigtable/Java/_index.md
@@ -9,7 +9,25 @@ aliases: [/integrations/google_cloud_bigtable/java]
 
 ![](/images/java.png)
 
-For more information, you can read about it here and get started [Bigtable docs](https://cloud.google.com/bigtable/docs).
+- [Introduction](#introduction)
+- [Packages to import](#packages-to-import)
+- [Enable Reporting](#enable-reporting)
+    - [Import packages](#import-packages)
+    - [Adding tracing](#adding-tracing)
+    - [End to end code sample](#end-to-end-code-sample)
+- [Running it](#running-it)
+    - [Maven install](#maven-install)
+    - [Run the code](#run-the-code)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Cloud Bigtable (cbt) is a petabyte-scale, fully managed NoSQL database service for large analytical and operational workloads.
+For more information you can read about it here and get started [Bigtable docs](https://cloud.google.com/bigtable/docs/how-to/)
+
+Cloud Bigtable's Java package was already instrumented for Tracing with OpenCensus.
+
+For more information, visit the [Bigtable docs](https://cloud.google.com/bigtable/docs).
 
 {{% notice note %}}
 This guide makes use of a couple of APIs
@@ -20,21 +38,9 @@ Bigtable how-to-guides|[Google Cloud Platform Bigtable how-to-guides](https://cl
 Stackdriver|[Stackdriver codelab](/codelabs/stackdriver/)
 {{% /notice %}}
 
-Cloud Bigtable (cbt) is a petabyte-scale, fully managed NoSQL database service for large analytical and operational workloads.
-For more information you can read about it here and get started [Bigtable docs](https://cloud.google.com/bigtable/docs/how-to/)
+## Enable Reporting
 
-Cloud Bigtable's Java package was already instrumented for:
-
-* Tracing with OpenCensus
-
-## Table of contents
-- [Packages to import](#packages-to-import)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Viewing your traces](#viewing-your-traces)
-
-#### Packages to import
-
+### Import packages
 For tracing and metrics on Bigtable, we'll import a couple of packages
 
 Package Name|Package link
@@ -45,7 +51,7 @@ The OpenCensus Java gRPC views|[io.opencensus.contrib.grpc.metrics.RpcViews](htt
 
 For the source code, please see [Java BigTable Hello world](https://cloud.google.com/bigtable/docs/samples-java-hello)
 
-##### Adding tracing
+### Adding tracing
 
 ```java
 import io.opencensus.common.Scope;
@@ -85,7 +91,7 @@ private void enableOpenCensusObservability() throws IOException {
 }
 ```
 
-##### End to end code sample
+### End to end code sample
 
 With all the steps combined, we'll finally have this code snippet, adapted from [Bigtable Java helloworld](https://cloud.google.com/bigtable/docs/samples-java-hello/)
 
@@ -408,19 +414,19 @@ public class BigtableOpenCensus implements AutoCloseable {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Running it
-##### Maven install
+## Running it
+### Maven install
 ```shell
 mvn install
 ```
 
-##### Run the code
+### Run the code
 ```shell
 mvn exec:java -Dexec.mainClass=io.opencensus.tutorials.bigtable.BigtableOpenCensus
 ```
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/integrations/google_cloud_datastore/Go.md
+++ b/content/guides/integrations/google_cloud_datastore/Go.md
@@ -8,6 +8,17 @@ aliases: [/integrations/google_cloud_datastore/go]
 
 ![](/images/gopher.png)
 
+- [Introduction](#introduction)
+- [Background](#background)
+- [Packages to import](#packages-to-import)
+- [Enable tracing](#enable-tracing)
+- [Add the trace exporter](#add-the-trace-exporter)
+- [End to end code sample](#end-to-end-code-sample)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Cloud Datastore's Go package was already instrumented for Tracing with OpenCensus.
+
 {{% notice note %}}
 This guide makes use of a couple of APIs
 
@@ -17,24 +28,13 @@ Cloud Datastore|[Enable Cloud Datastore](https://cloud.google.com/datastore)
 Stackdriver|[Please visit the Stackdriver codelab to set it up](/codelabs/stackdriver)
 {{% /notice %}}
 
-Cloud Datastore's Go package was already instrumented for:
-
-* Tracing with OpenCensus
-
-## Table of contents
-- [Background](#background)
-- [Packages to import](#packages-to-import)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Viewing your traces](#viewing-your-traces)
-
-#### Background
+## Background
 
 Our application is a segment of a source code mirroring service. It saves git commits and blobs to Cloud Datastore.
 With OpenCensus, we'll gain insights into how our distributed application is performing by instrumenting our application to examine
 traces.
 
-#### Packages to import
+## Packages to import
 
 For tracing on Datastore, we'll import the following packages
 
@@ -51,7 +51,7 @@ import (
 )
 {{</highlight>}}
 
-#### Enabling tracing
+## Enabling tracing
 
 To enable tracing, we'll follow the steps for tracing by:
 
@@ -64,7 +64,7 @@ defer span.End()
 _ = ctx // Use the context below
 {{</highlight>}}
 
-#### Add the trace exporter
+## Add the trace exporter
 The last step is to enable trace exporting. For that we'll use [Stackdriver Exporter](/supported-exporters/go/stackdriver)
 {{<highlight go>}}
 import (
@@ -87,7 +87,7 @@ func main() {
 {{</highlight>}}
 
 
-#### End to end code sample
+## End to end code sample
 
 With all the steps combined, we'll finally have this code snippet
 
@@ -218,7 +218,7 @@ func main() {
 }
 {{</highlight>}}
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)
 
 ![](/images/cloud_datastore_trace-go.png)

--- a/content/guides/integrations/google_cloud_spanner/Go.md
+++ b/content/guides/integrations/google_cloud_spanner/Go.md
@@ -9,6 +9,21 @@ aliases: [/integrations/google_cloud_spanner/go]
 
 ![](/images/gopher.png)
 
+- [Introduction](#introduction)
+- [Packages to import](#packages-to-import)
+- [Enable metric reporting](#register-views)
+    - [Register client metric views](#register-client-metric-views)
+    - [Register server metric views](#register-server-metric-views)
+    - [Exporting traces and metrics](#exporting-traces-and-metrics)
+    - [End to end code sample](#end-to-end-code-sample)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Cloud Spanner's Go package was already instrumented for:
+* Tracing with OpenCensus
+* Metrics with gRPC
+
 {{% notice note %}}
 This guide makes use of a couple of APIs
 
@@ -18,21 +33,7 @@ Spanner|[Spanner codelab](/codelabs/spanner)
 Stackdriver |[Stackdriver codelab](/codelabs/stackdriver)
 {{% /notice %}}
 
-Cloud Spanner's Go package was already instrumented for:
-* Tracing with OpenCensus
-* Metrics with gRPC
-
-## Table of contents
-- [Packages to import](#packages-to-import)
-- [Enable metric reporting](#register-views)
-    - [Register client metric views](#register-client-metric-views)
-    - [Register server metric views](#register-server-metric-views)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Viewing your traces](#viewing-your-traces)
-- [Viewing your metrics](#viewing-your-metrics)
-
-#### Packages to import
+## Packages to import
 
 For tracing and metrics on Spanner, we'll import a couple of packages
 
@@ -53,7 +54,7 @@ import (
 )
 {{</highlight>}}
 
-#### Enable metric reporting
+## Enable metric reporting
 
 To enable metric reporting/exporting, we need to enable a metrics exporter, but before that we'll need
 to register and enable the views that match the metrics to collect. For a complete list of the available views
@@ -61,25 +62,25 @@ available please visit [https://godoc.org/go.opencensus.io/plugin/ocgrpc](https:
 
 However, for now we'll split them into client and server views
 
-##### Register client metric views
+### Register client metric views
 {{<highlight go>}}
 if err := view.Register(ocgrcp.DefaultClientViews...); err != nil {
     log.Fatalf("Failed to register gRPC client views: %v", err)
 }
 {{</highlight>}}
 
-##### Register server metric views
+### Register server metric views
 {{<highlight go>}}
 if err := view.Register(ocgrcp.DefaultServerViews...); err != nil {
     log.Fatalf("Failed to register gRPC server views: %v", err)
 }
 {{</highlight>}}
 
-##### Exporting traces and metrics
+### Exporting traces and metrics
 The last step is to enable trace and metric exporting. For that we'll use say [Stackdriver Exporter](/supported-exporters/go/stackdriver) or
 any of the  [Go exporters](/supported-exporters/go/)
 
-##### End to end code sample
+### End to end code sample
 With all the steps combined, we'll finally have this code snippet
 {{<highlight go>}}
 package main
@@ -186,8 +187,8 @@ func newPlayers(ctx context.Context, client *spanner.Client, players ...*Player)
 }
 {{</highlight>}}
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/integrations/google_cloud_spanner/Java.md
+++ b/content/guides/integrations/google_cloud_spanner/Java.md
@@ -9,6 +9,23 @@ aliases: [/integrations/google_cloud_spanner/java]
 
 ![](/images/java.png)
 
+- [Introduction](#introduction)
+- [Packages to import](#packages-to-import)
+- [Enable metric reporting](#register-views)
+    - [Register gRPC views](#register-grpc-views)
+    - [Exporting traces and metrics](#exporting-traces-and-metrics)
+    - [End to end code sample](#end-to-end-code-sample)
+- [Running it](#running-it)
+    - [Maven install](#maven-install)
+    - [Run the code](#run-the-code)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Cloud Spanner's Java package was already instrumented for:
+* Tracing with OpenCensus
+* Metrics with gRPC
+
 {{% notice note %}}
 This guide makes use of a couple of APIs
 
@@ -18,25 +35,7 @@ Spanner|[Spanner codelab](/codelabs/spanner)
 Stackdriver |[Stackdriver codelab](/codelabs/stackdriver)
 {{% /notice %}}
 
-Cloud Spanner's Java package was already instrumented for:
-* Tracing with OpenCensus
-* Metrics with gRPC
-
-## Table of contents
-- [Packages to import](#packages-to-import)
-    - [Pom.xml](#pom.xml)
-- [Enable metric reporting](#register-views)
-    - [Register client metric views](#register-client-metric-views)
-    - [Register server metric views](#register-server-metric-views)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Running it](#running-it)
-    - [Maven install](#maven-install)
-    - [Run the code](#run-the-code)
-- [Viewing your traces](#viewing-your-traces)
-- [Viewing your metrics](#viewing-your-metrics)
-
-#### Packages to import
+## Packages to import
 
 For tracing and metrics on Spanner, we'll import a couple of packages
 
@@ -54,7 +53,7 @@ import io.opencensus.contrib.grpc.metrics.RpcViews;
 import io.opencensus.trace.Tracing;
 ```
 
-#### Enable metric reporting
+## Enable metric reporting
 
 To enable metric reporting/exporting, we need to enable a metrics exporter, but before that we'll need
 to register and enable the views that match the metrics to collect. For a complete list of the available views
@@ -62,17 +61,17 @@ available please visit [io.opencensus.contrib.grpc.metrics.RpcViews](https://git
 
 Finally, we'll register all the views
 
-##### Register gRPC views
+### Register gRPC views
 
 ```java
 RpcViews.registerAllGrpcViews();
 ```
 
-##### Exporting traces and metrics
+### Exporting traces and metrics
 The last step is to enable trace and metric exporting. For that we'll use say [Stackdriver Exporter](/supported-exporters/java/stackdriver) or
 any of the  [Java exporters](/supported-exporters/java/)
 
-##### End to end code sample
+### End to end code sample
 With all the steps combined, we'll finally have this code snippet
 
 {{<tabs Source Pom_xml>}}
@@ -283,19 +282,19 @@ public class SpannerOpenCensusTutorial {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Running it
-##### Maven install
+### Maven install
+## Running it
 ```shell
 mvn install
 ```
 
-##### Run the code
+### Run the code
 ```shell
 mvn exec:java -Dexec.mainClass=com.opencensus.tutorials.spanner -Dexec.args="census-demos demo1"
 ```
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/integrations/google_cloud_storage/Go.md
+++ b/content/guides/integrations/google_cloud_storage/Go.md
@@ -9,6 +9,23 @@ aliases: [/integrations/google_cloud_spanner/go]
 
 ![](/images/gopher.png)
 
+- [Introduction](#introduction)
+- [Packages to import](#packages-to-import)
+- [Technical detour](#technical-detour)
+- [Setting up the ochttp enabled transport](#setting-up-the-ochttp-enabled-transport)
+- [Enable metric reporting](#enable-metric-reporting)
+    - [Register client metric views](#register-client-metric-views)
+    - [Register server metric views](#register-server-metric-views)
+    - [Exporting traces and metrics](#exporting-traces-and-metrics)
+    - [End to end code sample](#end-to-end-code-sample)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Google Cloud Storage (GCS) is a unified object storage for developers and enterprises, managed by Google.
+For more information you can read about it here and get started [Storage docs](https://godoc.org/cloud.google.com/go/storage/docs)
+
+Cloud Storage 's Go package was already instrumented for Tracing with OpenCensus.
+
 {{% notice note %}}
 This guide makes use of a couple of APIs
 
@@ -18,21 +35,8 @@ Storage |[Storage codelab](/codelabs/storage)
 Stackdriver |[Stackdriver codelab](/codelabs/stackdriver)
 {{% /notice %}}
 
-Google Cloud Storage (GCS) is a unified object storage for developers and enterprises, managed by Google.
-For more information you can read about it here and get started [Storage docs](https://godoc.org/cloud.google.com/go/storage/docs)
 
-Cloud Storage 's Go package was already instrumented for:
-
-* Tracing with OpenCensus
-
-## Table of contents
-- [Packages to import](#packages-to-import)
-- [Technical detour](#technical-detour)
-- [Enable tracing](#enable-tracing)
-- [End to end code sample](#end-to-end-code-sample)
-- [Viewing your traces](#viewing-your-traces)
-
-#### Packages to import
+## Packages to import
 
 For tracing and metrics on Spanner, we'll import a couple of packages
 
@@ -54,12 +58,12 @@ import (
 )
 {{</highlight>}}
 
-#### Technical detour
+## Technical detour
 
 Because GCS uses HTTP to connect to Google's backend, we'll need to enable metrics and tracing using a custom client
 for GCP uploads. The custom client will have an `ochttp` enabled transport and then the rest is simple
 
-##### Setting up the ochttp enabled transport
+## Setting up the ochttp enabled transport
 
 {{<highlight go>}}
 import (
@@ -73,7 +77,7 @@ hc := &http.Client{Transport: new(ochttp.Transport)}
 gcsClient := storage.NewClient(context.Background())
 {{</highlight>}}
 
-#### Enable metric reporting
+## Enable metric reporting
 
 To enable metric reporting/exporting, we need to enable a metrics exporter, but before that we'll need
 to register and enable the views that match the HTTP metrics to collect. For a complete list of the available views
@@ -81,25 +85,25 @@ available please visit [https://godoc.org/go.opencensus.io/plugin/ochttp](https:
 
 However, for now we'll split them into client and server views
 
-##### Register client metric views
+### Register client metric views
 {{<highlight go>}}
 if err := view.Register(ochttp.DefaultClientViews...); err != nil {
     log.Fatalf("Failed to register HTTP client views: %v", err)
 }
 {{</highlight>}}
 
-##### Register server metric views
+### Register server metric views
 {{<highlight go>}}
 if err := view.Register(ochttp.DefaultServerViews...); err != nil {
     log.Fatalf("Failed to register HTTP server views: %v", err)
 }
 {{</highlight>}}
 
-##### Exporting traces and metrics
+### Exporting traces and metrics
 The last step is to enable trace and metric exporting. For that we'll use say [Stackdriver Exporter](/supported-exporters/go/stackdriver) or
 any of the  [Go exporters](/supported-exporters/go/)
 
-##### End to end code sample
+### End to end code sample
 With all the steps combined, we'll finally have this code snippet
 {{<highlight go>}}
 package main
@@ -186,9 +190,9 @@ func main() {
 }
 {{</highlight>}}
 
-#### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-#### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)
 ![](/images/gcs_go_trace.png)

--- a/content/guides/integrations/memcached/Go.md
+++ b/content/guides/integrations/memcached/Go.md
@@ -7,7 +7,6 @@ aliases: [/integrations/memcached/go]
 
 ![memcached logo](/img/memcached-gopher.png)
 
-### Table of contents
 - [Introduction](#introduction)
 - [Features](#features)
     - [Trace updates](#trace-updates)
@@ -21,24 +20,22 @@ aliases: [/integrations/memcached/go]
 - [Examining your metrics](#enabling-your-metrics)
 - [References](#references)
 
-#### Introduction
-
+## Introduction
 [Memcached](https://memcached.org) is one of the most used server caching and scaling technologies.
 
-It was created by [Brad Fitzpatrick](https://en.wikipedia.org/wiki/Brad_Fitzpatrick) in 2003 as a 
+It was created by [Brad Fitzpatrick](https://en.wikipedia.org/wiki/Brad_Fitzpatrick) in 2003 as a
 solution to scale his social media product [Live Journal](https://www.livejournal.com/)
 
-#### Features
+## Features
 
-##### Trace updates
+### Trace updates
 OpenCensus Go was used to instrument Brad's original Memcache client, with 2 major changes:
 
 * `Set`, `Get`, `GetMulti`, `Add`, `Replace`, `Delete`, `DeleteAll`, `Decrement`, `CompareAndSwap`, `Touch`, `Each`
 
 all now take in a context.Context object as the first argument, to allow for trace propagation.
 
-##### Available metrics
-
+### Available metrics
 * Also a couple of metrics have been added:
 
 Metric|Name|Description
@@ -53,17 +50,15 @@ Distribution of value lengths|`value_length`|The distributions and counts of val
 Distribution of latencies in milliseconds|`latency`|The distributions and counts of latencies in milliseconds, by tag "method"
 Number of calls|`calls`|The number of calls broken down by tag key `method`
 
-##### Using it
-
+## Using it
 ```shell
 go get -u -v github.com/orijtech/gomemcache/memcache
 ```
 
-##### Enabling OpenCensus
-
+## Enabling OpenCensus
 To provide observability we'll enable OpenCensus tracing and metrics
 
-###### Enabling Metrics
+### Enabling Metrics
 {{<highlight go>}}
 package main
 
@@ -82,11 +77,10 @@ func main() {
 }
 {{</highlight>}}
 
-###### Enabling Tracing
+### Enabling Tracing
 You'll just to enable any of the trace exporter in [Go exporters](/guides/exporters/supported-exporters/go/)
 
-##### End to end example
-
+## End to end example
 {{% notice tip %}}
 For assistance installing Memcached, please visit the [Memcached Installation wiki](https://github.com/memcached/memcached/wiki/Install)
 {{% /notice %}}
@@ -231,7 +225,7 @@ func enableOpenCensusTracingAndMetrics() (func(), error) {
 }
 {{</highlight>}}
 
-##### Examining your traces
+## Examining your traces
 
 Please visit https://console.cloud.google.com/traces
 
@@ -239,7 +233,7 @@ Opening our console will produce something like
 
 ![Trace](/img/memcache-trace-comparison.png)
 
-##### Examining your metrics
+## Examining your metrics
 Please visit https://console.cloud.google.com/monitoring
 
 * Metrics list
@@ -261,7 +255,7 @@ Please visit https://console.cloud.google.com/monitoring
 * Errors grouped by "reason" and "method"
 ![Errors disambiguated](/img/memcache-metrics-errors-disambiguated.png)
 
-##### References
+## References
 
 Resource|URL
 ---|---

--- a/content/guides/integrations/redis/Java.md
+++ b/content/guides/integrations/redis/Java.md
@@ -8,25 +8,26 @@ aliases: [/integrations/redis/java]
 
 ![](/images/java-opencensus.png)
 
+- [Introduction](#introduction)
+- [Prerequisites](#prerequisites)
+- [Generating the JAR](#generating-the-jar)
+    - [Clone this repository](#clone-this-repository)
+    - [Generate and install](#generate-and-install)
+- [Enabling observability](#enabling-observability)
+- [Available metrics](#available-metrics)
+- [End to end example](#end-to-end-example)
+    - [Running it](#running-it)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
 Some Redis clients were already instrumented to provide traces and metrics with OpenCensus
 
 Packages|Repository link
 ---|---
 jedis|https://github.com/opencensus-integrations/jedis
 
-## Table of contents
-- [prerequisites](#prerequisites)
-- [Generating the JAR](#generating-the-jar)
-    - [Clone this repository](#clone-this-repository)
-    - [Generate and install](#generate-and-install)
-- [Available metrics](#available-metrics)
-- [Enabling observability](#enabling-observability)
-- [End to end example](#end-to-end-example)
-    - [Running it](#running-it)
-- [Viewing your metrics](#viewing-your-metrics)
-- [Viewing your traces](#viewing-your-traces)
-
-#### Prerequisites
+## Prerequisites
 
 You will need the following:
 
@@ -39,14 +40,14 @@ For assistance installing Redis, please [Click here to get started](https://redi
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Generating the JAR
+## Generating the JAR
 
-##### Clone this repository
+### Clone this repository
 ```shell
 git clone https://github.com/opencensus-integrations
 ```
 
-##### Generating the JAR
+### Generate and install
 Inside the cloned repository's directory run
 ```shell
 mvn install:install-file -Dfile=$(pwd)/target/jedis-3.0.0-SNAPSHOT.jar \
@@ -54,7 +55,7 @@ mvn install:install-file -Dfile=$(pwd)/target/jedis-3.0.0-SNAPSHOT.jar \
 -Dpackaging=jar -DgeneratePom=true
 ```
 
-#### Enabling observability
+## Enabling observability
 To enable observability, we'll need to use Jedis normally but with one change
 
 {{<highlight java>}}
@@ -67,7 +68,7 @@ and then finally to enable metrics
 Observability.registerAllViews();
 {{</highlight>}}
 
-#### Available metrics
+## Available metrics
 Metric search suffix|Description
 ---|---
 redis/bytes_read|The number of bytes read from the Redis server
@@ -80,7 +81,7 @@ redis/roundtrip_latency|The latency spent for various Redis operations
 redis/reads|The number of reads performed
 redis/writes|The number of writes performed
 
-#### End to end example
+## End to end example
 {{<tabs Source Pom>}}
 
 {{<highlight java>}}
@@ -254,13 +255,13 @@ public class JedisOpenCensus {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Running it
+### Running it
 ```shell
 mvn install && mvn exec:java -Dexec.mainClass=io.opencensus.tutorials.jedis.JedisOpenCensus
 ```
 
-##### Viewing your metrics
+## Viewing your metrics
 Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
-##### Viewing your traces
+## Viewing your traces
 Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/guides/integrations/sql/go_sql.md
+++ b/content/guides/integrations/sql/go_sql.md
@@ -7,9 +7,7 @@ aliases: [/integrations/sql/go]
 
 ![](/img/sql-gopher.png)
 
-We have a Go "database/sql" package/wrapper that is trace instrumented with OpenCensus!
-
-#### Table of contents
+- [Introduction](#Introduction)
 - [Installing it](#installing-it)
 - [Using it](#using-it)
   - [By registration](#by-registration)
@@ -19,15 +17,16 @@ We have a Go "database/sql" package/wrapper that is trace instrumented with Open
 - [Examining the traces](#examining-the-traces)
 - [References](#references)
 
-##### Installing it
+## Introduction
+We have a Go "database/sql" package/wrapper that is trace instrumented with OpenCensus!
 
+## Installing it
 To install the "database/sql" plugin, please run
 ```shell
 go get -u -v github.com/basvanbeek/ocsql
 ```
 
-##### Using it
-
+## Using it
 Given this simple initialization of a database/sql instance in Go:
 
 {{<highlight go>}}
@@ -50,8 +49,7 @@ func main() {
 
 We can use the OpenCensus trace-instrumented SQL driver wrapper in one of these two ways:
 
-###### By registration
-
+### By registration
 This mimicks the idiomatic recommendation to use the "database/sql" package in Go where
 we pass an implicitly registered driver to `sql.Open` which returns a [\*sql.DB handle](https://golang.org/pkg/database/sql/#DB)
 
@@ -81,8 +79,7 @@ func main() {
 }
 {{</highlight>}}
 
-###### By explicitly wrapping your driver
-
+### By explicitly wrapping your driver
 This option is useful if you'd like to be more explicit and if your database package exports
 its driver implementation.
 
@@ -97,12 +94,10 @@ func main() {
 }
 {{</highlight>}}
 
-##### Enabling OpenCensus
-
+## Enabling OpenCensus
 To examine the traces, we need to hook up our favorite Go exporter as per the [Go exporters guides](/guides/exporters/supported-exporters/go/)
 
-##### End to end example
-
+## End to end example
 And now to examine the exported traces, let's make a simple name registry app.
 For simplicitly, we use a sqlite3 database. To examine our traces, we'll use Jaeger.
 {{% notice tip %}}
@@ -219,8 +214,7 @@ func enableOpenCensusTracingAndExporting() error {
 }
 {{</highlight>}}
 
-###### Examine the traces
-
+## Examine the traces
 On visiting http://localhost:16686/ we can see something similar to below:
 
 ![Traces list](/img/ocsql-all-traces.png)
@@ -229,8 +223,7 @@ and on clicking to get details about the most recent trace
 
 ![Detailed trace](/img/ocsql-detailed-trace.png)
 
-###### References
-
+## References
 Reference|URL
 ---|---
 GoDoc|[github.com/basvanbeek/ocsql](https://godoc.org/github.com/basvanbeek/ocsql)

--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -5,8 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Brief Overview](#brief-overview)
@@ -32,7 +30,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View the metrics on the backend of our choice
 
-#### Requirements
+## Requirements
 - Go 1.9 or above
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
@@ -41,13 +39,13 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Installation
+## Installation
 
 OpenCensus: `go get -u -v go.opencensus.io/...`
 
 Stackdriver exporter: `go get -u -v contrib.go.opencensus.io/exporter/stackdriver`
 
-#### Brief Overview
+## Brief Overview
 By the end of this tutorial, we will do these four things to obtain metrics using OpenCensus:
 
 1. Create quantifiable metrics (numerical) that we will record
@@ -56,7 +54,7 @@ By the end of this tutorial, we will do these four things to obtain metrics usin
 4. Export our views to a backend (Stackdriver in this case)
 
 
-#### Getting Started
+## Getting Started
 
 {{% notice note %}}
 Unsure how to write and execute Go code? [Click here](https://golang.org/doc/code.html).
@@ -131,10 +129,10 @@ func processLine(in []byte) (out []byte, err error) {
 
 You can run the code via `go run repl.go`.
 
-#### Enable Metrics
+## Enable Metrics
 
 <a name="import-metrics-packages"></a>
-##### Import Packages
+### Import Packages
 
 To enable metrics, we’ll import a number of core and OpenCensus packages.
 
@@ -215,7 +213,7 @@ func processLine(in []byte) (out []byte, err error) {
 {{</tabs>}}
 
 <a name="create-metrics"></a>
-##### Create Metrics
+### Create Metrics
 
 First, we will create the variables needed to later record our metrics.
 
@@ -309,7 +307,7 @@ func processLine(in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Tags
+### Create Tags
 
 Now we will create the variable later needed to add extra text meta-data to our metrics.
 
@@ -406,7 +404,7 @@ osKey, _ := tag.NewKey("operating_system")
 
 Later, when we use osKey, we will be given an opportunity to enter values such as "windows" or "mac".
 
-##### Inserting Tags
+### Inserting Tags
 Now we will insert a specific tag called "repl". It will give us a new `context.Context ctx` which we will use while we later record our metrics. This `ctx` has all tags that have previously been inserted, thus allowing for context propagation.
 
 {{<tabs Snippet All>}}
@@ -603,7 +601,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Recording Metrics
+### Recording Metrics
 
 Now we will record the desired metrics. To do so, we will use `stats.Record` and pass in our `ctx` and [previously instantiated metrics variables](#create-metrics).
 
@@ -738,11 +736,11 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Enable Views
+## Enable Views
 We will be adding the View package: `"go.opencensus.io/stats/view"`
 
 <a name="import-views-packages"></a>
-##### Import Packages
+### Import Packages
 {{<tabs Snippet All>}}
 {{<highlight go>}}
 import (
@@ -854,7 +852,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Views
+### Create Views
 We now determine how our metrics will be organized by creating `Views`.
 
 {{<tabs Snippet All>}}
@@ -1021,7 +1019,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Register Views
+### Register Views
 We now register the views and set the reporting period.
 
 {{<tabs Snippet All>}}
@@ -1181,10 +1179,10 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Exporting to Stackdriver
+## Exporting to Stackdriver
 
 <a name="import-exporting-packages"></a>
-##### Import Packages
+### Import Packages
 We will be adding the Stackdriver package: `"contrib.go.opencensus.io/exporter/stackdriver"`
 
 {{<tabs Snippet All>}}
@@ -1339,7 +1337,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Export Views
+### Export Views
 In our `main` function, first we create the Stackdriver exporter:
 ```go
 // Create that Stackdriver stats exporter
@@ -1543,7 +1541,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your Metrics on Stackdriver
+## Viewing your Metrics on Stackdriver
 With the above you should now be able to navigate to the [Google Cloud Platform console](https://app.google.stackdriver.com/metrics-explorer), select your project, and view the metrics.
 
 In the query box to find metrics, type `quickstart` as a prefix:

--- a/content/quickstart/go/tracing.md
+++ b/content/quickstart/go/tracing.md
@@ -5,8 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
@@ -25,7 +23,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View traces on the backend of our choice
 
-#### Requirements
+## Requirements
 - Go 1.9 or above
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
@@ -34,13 +32,13 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Installation
+## Installation
 
 OpenCensus: `go get go.opencensus.io/*`
 
 Stackdriver exporter: `go get contrib.go.opencensus.io/exporter/stackdriver`
 
-#### Getting Started
+## Getting Started
 
 {{% notice note %}}
 Unsure how to write and execute Go code? [Click here](https://golang.org/doc/code.html).
@@ -116,10 +114,10 @@ func processLine(in []byte) (out []byte, err error) {
 
 You can run the code via `go run repl.go`.
 
-#### Enable Tracing
+## Enable Tracing
 
 <a name="import-tracing-packages"></a>
-##### Import Packages
+### Import Packages
 
 To enable tracing, we’ll import the context package (`context`) as well as the OpenCensus Trace package (`go.opencensus.io/trace`). Your import statement will look like this:
 
@@ -201,7 +199,7 @@ func processLine(in []byte) (out []byte, err error) {
 {{</tabs>}}
 
 <a name="instrument-tracing"></a>
-##### Instrumentation
+### Instrumentation
 
 We will be tracing the execution as it starts in `readEvaluateProcess`, goes to `readLine`, and finally travels through `processLine`.
 
@@ -341,10 +339,10 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 
 When creating a new span with `trace.StartSpan(context.Context, "spanName")`, the package first checks if a parent Span already exists in the `context.Context` argument. If it exists, a child span is created. Otherwise, a newly created span is inserted in to `context` to become the parent Span so that subsequent reuse of `context.Context` will have that span.
 
-#### Exporting to Stackdriver
+## Exporting to Stackdriver
 
 <a name="import-exporting-packages"></a>
-##### Import Packages
+### Import Packages
 To turn on Stackdriver Tracing, we’ll need to import the Stackdriver exporter from `contrib.go.opencensus.io/exporter/stackdriver`.
 
 {{<tabs Snippet All>}}
@@ -438,7 +436,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Export Traces
+### Export Traces
 To get our code ready to export, we will be adding a few lines of code to our `main` function.
 
 1. We want to make our traces export to Stackdriver
@@ -581,7 +579,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Annotations
+### Create Annotations
 When looking at our traces on a backend (such as Stackdriver), we can add metadata to our traces to increase our post-mortem insight.
 
 Let's record the length of each requested string so that it is available to view when we are looking at our traces. We can do this by annotating our `readEvaluateProcess` function.
@@ -715,7 +713,7 @@ func processLine(ctx context.Context, in []byte) (out []byte, err error) {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your Traces on Stackdriver
+## Viewing your Traces on Stackdriver
 With the above you should now be able to navigate to the [Google Cloud Platform console](https://console.cloud.google.com/traces/traces), select your project, and view the traces.
 
 ![viewing traces 1](https://cdn-images-1.medium.com/max/1600/1*v7qiO8nX8WAxpX4LjiQ2oA.png)

--- a/content/quickstart/java/tracing.md
+++ b/content/quickstart/java/tracing.md
@@ -5,8 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
@@ -25,7 +23,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View traces on the backend of our choice
 
-#### Requirements
+## Requirements
 - Java 8+
 - [Apache Maven](https://maven.apache.org/install.html)
 - Google Cloud Platform account and project
@@ -37,7 +35,7 @@ For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a
 For assistance setting up Apache Maven, [Click here](https://maven.apache.org/install.html) for instructions.
 {{% /notice %}}
 
-#### Installation
+## Installation
 We will first create our project directory, generate the `pom.xml`, and bootstrap our entry file.
 
 ```bash
@@ -167,7 +165,7 @@ To install required dependencies, run this from your project's root directory:
 mvn install
 ```
 
-#### Getting Started
+## Getting Started
 The Repl application takes input from users, converts any lower-case letters into upper-case letters, and echoes the result back to the user, for example:
 ```bash
 > foo
@@ -184,9 +182,9 @@ You will be given a text prompt. Try typing in a lowercase word and hit enter to
 You should see something like this after a few tries:
 ![java image 1](https://cdn-images-1.medium.com/max/1600/1*VFN-txsDL6qYkN_UH3VwhA.png)
 
-#### Enable Tracing
+## Enable Tracing
 
-##### Import Packages
+### Import Packages
 To enable tracing, we’ll declare the dependencies in your `pom.xml` file. Insert the following code snippet after the `<properties>...</properties>` node:
 
 {{<tabs Snippet All>}}
@@ -345,7 +343,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Instrumentation
+### Instrumentation
 We will begin by creating a private static `Tracer` as a property of our Repl class.
 
 ```java
@@ -423,9 +421,9 @@ public class Repl {
 }
 ```
 
-#### Exporting to Stackdriver
+## Exporting to Stackdriver
 
-##### Import Packages
+### Import Packages
 To turn on Stackdriver Tracing, we’ll need to declare the Stackdriver dependency in your `pom.xml`. Add the following code snippet inside of your `<dependencies>` node:
 
 {{<tabs Snippet All>}}
@@ -600,7 +598,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-##### Export Traces
+### Export Traces
 We will create a function called `setupOpenCensusAndStackdriverExporter` and call it from our `main` function:
 
 {{<tabs Snippet All>}}
@@ -957,7 +955,7 @@ public class Repl {
 {{</tabs>}}
 
 
-##### Create Annotations
+### Create Annotations
 When looking at our traces on a backend (such as Stackdriver), we can add metadata to our traces to increase our post-mortem insight.
 
 Let's record the length of each requested string so that it is available to view when we are looking at our traces.
@@ -1172,7 +1170,7 @@ public class Repl {
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your Traces on Stackdriver
+## Viewing your Traces on Stackdriver
 With the above you should now be able to navigate to the [Google Cloud Platform console](https://console.cloud.google.com/traces/traces), select your project, and view the traces.
 
 ![Trace list](/img/quickstart-traces-java-tracelist.png)

--- a/content/quickstart/python/metrics.md
+++ b/content/quickstart/python/metrics.md
@@ -8,8 +8,6 @@ class: "shadowed-image lightbox"
 This tutorial is incomplete, pending OpenCensus Python adding Metrics exporters
 {{% /notice %}}
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Brief Overview](#brief-overview)
@@ -24,7 +22,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View the metrics on the backend of our choice
 
-#### Requirements
+## Requirements
 - Python2 and above
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
@@ -33,11 +31,11 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Installation
+## Installation
 
 OpenCensus: `pip install --upgrade opencensus google-cloud-monitoring`
 
-#### Brief Overview
+## Brief Overview
 By the end of this tutorial, we will do these four things to obtain metrics using OpenCensus:
 
 1. Create quantifiable metrics (numerical) that we will record
@@ -46,7 +44,7 @@ By the end of this tutorial, we will do these four things to obtain metrics usin
 4. Export our views to a backend (Stackdriver in this case)
 
 
-#### Getting Started
+## Getting Started
 
 {{% notice note %}}
 Unsure how to write and execute Python code? [Click here](https://docs.python.org/).
@@ -85,12 +83,8 @@ if __name__ == '__main__':
 
 You can run the code via `python repl.py`.
 
-#### Create and record Metrics
-
-<a name="import-metrics-packages"></a>
-##### Import Packages
-
-To enable metrics, we’ll import a number of core and OpenCensus packages.
+## Create and record Metrics
+Now we'll import the required packages and instrument our code.
 
 {{<tabs Snippet All>}}
 {{<highlight python>}}
@@ -185,7 +179,7 @@ if __name__ == "__main__":
 {{</highlight>}}
 {{</tabs>}}
 
-#### With views and all enabled
+## With views and all enabled
 ```python
 #!/usr/bin/env python
 
@@ -278,7 +272,7 @@ if __name__ == "__main__":
     main()
 ```
 
-#### Exporting to Stackdriver
+## Exporting to Stackdriver
 
 {{% notice warning %}}
 This tutorial is incomplete, pending OpenCensus Python adding Metrics exporters

--- a/content/quickstart/python/tracing.md
+++ b/content/quickstart/python/tracing.md
@@ -5,8 +5,6 @@ draft: false
 class: "shadowed-image lightbox"
 ---
 
-#### Table of contents
-
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Getting started](#getting-started)
@@ -15,7 +13,6 @@ class: "shadowed-image lightbox"
     - [Instrumentation](#instrument-tracing)
 - [Exporting to Stackdriver](#exporting-to-stackdriver)
     - [Import Packages](#import-exporting-packages)
-    - [Export Traces](#export-traces)
     - [Create Annotations](#create-annotations)
 - [Viewing your Traces on Stackdriver](#viewing-your-traces-on-stackdriver)
 
@@ -25,7 +22,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 2. Register and enable an exporter for a [backend](/core-concepts/exporters/#supported-backends) of our choice
 3. View traces on the backend of our choice
 
-#### Requirements
+## Requirements
 - Python
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
@@ -34,11 +31,11 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
 {{% /notice %}}
 
-#### Installation
+## Installation
 
 OpenCensus: `pip install opencensus google-cloud-trace`
 
-#### Getting Started
+## Getting Started
 
 {{% notice note %}}
 Unsure how to write and execute Python code? [Click here](https://docs.python.org/).
@@ -69,10 +66,10 @@ def main():
 
 You can run the code via `python repl.py`.
 
-#### Enable Tracing
+## Enable Tracing
 
 <a name="import-tracing-packages"></a>
-##### Import Packages
+### Import Packages
 
 To enable tracing, we’ll import the `trace.tracer` package from `opencensus`
 {{<tabs Snippet All>}}
@@ -99,7 +96,7 @@ def main():
 {{</tabs>}}
 
 <a name="instrument-tracing"></a>
-##### Instrumentation
+### Instrumentation
 
 We will be tracing the execution as it starts in `readEvaluateProcessLine`, goes to `readLine`, and finally travels through `processLine`.
 
@@ -147,10 +144,10 @@ def readEvaluateProcessLine():
 
 When creating a new span with `tracer.span("spanName")`, the package first checks if a parent Span already exists in the current thread local storage/context. If it exists, a child span is created. Otherwise, a newly created span is inserted in to the thread local storage/context to become the parent Span.
 
-#### Exporting traces to Stackdriver
+## Exporting traces to Stackdriver
 
 <a name="import-exporting-packages"></a>
-##### Import Packages
+### Import Packages
 To turn on Stackdriver Tracing, we’ll need to import the Stackdriver exporter from `opencensus.trace.exporters`
 
 {{<tabs Snippet All>}}
@@ -197,7 +194,7 @@ def processInput(tracer, data):
 {{</highlight>}}
 {{</tabs>}}
 
-##### Create Annotations
+### Create Annotations
 We can add metadata to our traces to increase our post-mortem insight.
 
 Let's record the length of each requested string so that it is available to view when we are looking at our traces. We can do this by annotating our `readEvaluateProcessLine` function.
@@ -252,7 +249,7 @@ if __name__ == "__main__":
 {{</highlight>}}
 {{</tabs>}}
 
-#### Viewing your Traces on Stackdriver
+## Viewing your Traces on Stackdriver
 With the above you should now be able to navigate to the [Google Cloud Platform console](https://console.cloud.google.com/traces/traces), select your project, and view the traces.
 
 ![viewing traces 1](/images/python-trace-overall.png)


### PR DESCRIPTION
This PR standardizes the format on all pages found within `/quickstarts` and `/guides`.

The format is as follows:

- image (if present)
- table of contents
- introduction (if present)
- note at end of introduction (if present)
- rest of article. sections are `<h2>`, subsections are `<h3>`

Things found in this PR:

- removed "table of contents" text
- moved the table of contents to beginning of page (following an image if image is present)
- added "introduction" to many articles
- moved "note" found in what would be the introduction to the end of the introduction
- fixed some discrepancies in articles that contained a table of contents that did not match the article structure
- rearranged some articles to fit a similar flow
- made all section titles to be `<h2>` and all subsections to be `<h3>`