### PR TITLE
content: rename Node to Node.js

### DIFF
--- a/content/quickstart/node.js/_index.md
+++ b/content/quickstart/node.js/_index.md
@@ -1,8 +1,9 @@
 ---
-title: "Node"
+title: "Node.js"
 date: 2018-07-16T14:29:03-07:00
 draft: false
 class: "resized-logo"
+url: quickstart/nodejs
 ---
 
 ![](/images/node-opencensus.png)

--- a/content/quickstart/node.js/tracing.md
+++ b/content/quickstart/node.js/tracing.md
@@ -3,6 +3,7 @@ title: "Tracing"
 date: 2018-07-22T20:29:06-07:00
 draft: false
 class: "shadowed-image lightbox"
+url: quickstart/nodejs/tracing
 ---
 
 - [Requirements](#requirements)
@@ -24,7 +25,7 @@ In this quickstart, we’ll gleam insights from code segments and learn how to:
 3. View traces on the backend of our choice
 
 ## Requirements
-- Node
+- [Node.js](https://nodejs.org/) 6 or above and `npm` (already comes with Node.js)
 - Google Cloud Platform account and project
 - Google Stackdriver Tracing enabled on your project
 
@@ -725,7 +726,7 @@ const defaultConfig = {
   samplingRate: 1.0  // always sample
 };
 
-const exporter = new stackdriver.StackdriverTraceExporter({projectId: 'your-project-id'});
+const exporter = new stackdriver.StackdriverTraceExporter({projectId: getProjectId()});
 
 const tracer = tracing.start().tracer;
 tracer.registerSpanEventListener(exporter);

--- a/layouts/shortcodes/quickstart-list.html
+++ b/layouts/shortcodes/quickstart-list.html
@@ -48,3 +48,14 @@ Metrics
 >
 Tracing
 </a>
+
+<div class="quickstart-list-header">
+  <img src="/images/nodejs.png">
+  <h5>Node.js</h5>
+</div>
+<a
+  class="btn btn-info"
+  onclick="location.href='nodejs/tracing'"
+>
+Tracing
+</a>


### PR DESCRIPTION
1. Renames path of `/quickstarts/node/*` to `/quickstarts/nodejs`
2. Renames "Node" to "Node.js" on `/quickstarts/nodejs`
3. Adds Node.js to `/quickstarts`
4. Fixes exporter error