### PR TITLE
Node exporters

### DIFF
--- a/content/guides/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Go/Prometheus.md
@@ -26,7 +26,6 @@ OpenCensus Go allows exporting stats to Prometheus by means of the Prometheus pa
 For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
 {{% /notice %}}
 
-
 ## Creating the exporter
 To create the exporter, we'll need to:
 

--- a/content/guides/exporters/supported-exporters/Node.js/Instana.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Instana.md
@@ -11,7 +11,7 @@ logo: /images/instana.png
 - [Creating the exporter](#creating-the-exporter)
 
 ## Introduction
-Instant provides AI Powered Application and Infrastructure Monitoring, allowing you to
+Instanta provides AI Powered Application and Infrastructure Monitoring, allowing you to
 deliver Faster With Confidence, and automatic Analysis and Optimization.
 
 OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-instana](https://www.npmjs.com/package/@opencensus/exporter-instana)

--- a/content/guides/exporters/supported-exporters/Node.js/Instana.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Instana.md
@@ -1,0 +1,41 @@
+---
+title: "Instana (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /images/instana.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Instant provides AI Powered Application and Infrastructure Monitoring, allowing you to
+deliver Faster With Confidence, and automatic Analysis and Optimization.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-instana](https://www.npmjs.com/package/@opencensus/exporter-instana)
+
+More information can be found at the [Instana website](https://www.instana.com/)
+
+## Installing the exporter
+You can install OpenCensus Instana Exporter by running these steps:
+
+```bash
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-instana
+```
+
+To use Instana as your exporter, first ensure that you have an [Instana agent running on your system](https://docs.instana.io/quick_start/getting_started/) and reporting to your environment. The Instana OpenCensus exporter directly communicates with the Instana agent in order to transmit data to Instana.
+
+## Creating the exporter
+Now let's use the Instana exporter:
+
+```js
+var tracing = require('@opencensus/nodejs');
+var instana = require('@opencensus/exporter-instana');
+
+var exporter = new instana.InstanaTraceExporter();
+
+tracing.registerExporter(exporter).start();
+```

--- a/content/guides/exporters/supported-exporters/Node.js/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Jaeger.md
@@ -1,0 +1,59 @@
+---
+title: "Jaeger (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/partners/jaeger_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
+It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+* Distributed context propagation
+* Distributed transaction monitoring
+* Root cause analysis
+* Service dependency analysis
+* Performance / latency optimization
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-jaeger](https://www.npmjs.com/package/@opencensus/exporter-jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Jaeger Exporter by running these steps:
+
+```bash
+npm install @opencensus/core
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-jaeger
+```
+
+## Creating the exporter
+Now let's use the Jaeger exporter:
+
+```js
+var core = require('@opencensus/core');
+var tracing = require('@opencensus/nodejs');
+var jaeger = require('@opencensus/exporter-jaeger');
+
+var jaegerOptions = {
+  serviceName: 'opencensus-exporter-jaeger',
+  host: 'localhost',
+  port: 6832,
+  tags: [{key: 'opencensus-exporter-jeager', value: '0.0.1'}],
+  bufferTimeout: 10, // time in milliseconds
+  logger: core.logger('debug'),
+  maxPacketSize: 1000
+};
+
+var exporter = new jaeger.JaegerTraceExporter();
+
+tracing.registerExporter(exporter).start();
+```

--- a/content/guides/exporters/supported-exporters/Node.js/Prometheus.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Prometheus.md
@@ -1,0 +1,50 @@
+---
+title: "Prometheus (Stats)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/prometheus-logo.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Prometheus is a monitoring system that collects metrics, by scraping
+exposed endpoints at regular intervals, evaluating rule expressions.
+It can also trigger alerts if certain conditions are met.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-prometheus](https://www.npmjs.com/package/@opencensus/exporter-prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Prometheus Exporter by running these steps:
+
+```bash
+npm install @opencensus/core
+npm install @opencensus/exporter-prometheus
+```
+
+## Creating the exporter
+Now let's use the Prometheus exporter:
+
+```js
+var {AggregationType, Measure, MeasureUnit, Stats} = require('@opencensus/core');
+var prometheus = require('@opencensus/exporter-prometheus');
+
+var stats = new Stats();
+
+var exporter = new prometheus.PrometheusTraceExporter({
+  port: 9464,
+  startServer: false
+});
+stats.registerExporter(exporter);
+
+exporter.startServer(function callback() {
+  // Callback
+});
+```

--- a/content/guides/exporters/supported-exporters/Node.js/Zipkin.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Zipkin.md
@@ -1,0 +1,48 @@
+---
+title: "Zipkin (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/zipkin-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
+
+It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-zipkin](https://www.npmjs.com/package/@opencensus/exporter-zipkin)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Zipkin Exporter by running these steps:
+
+```bash
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-zipkin
+```
+
+## Creating the exporter
+Now let's use the Zipkin exporter:
+
+```js
+var tracing = require('@opencensus/nodejs');
+var zipkin = require('@opencensus/exporter-zipkin');
+
+// Add your zipkin url (ex http://localhost:9411/api/v2/spans)
+// and application name to the Zipkin options
+var options = {
+  url: 'your-zipkin-url',
+  serviceName: 'your-application-name'
+};
+
+var exporter = new zipkin.ZipkinTraceExporter(options);
+tracing.registerExporter(exporter).start();
+```

--- a/content/guides/exporters/supported-exporters/Node.js/stackdriver-stats.md
+++ b/content/guides/exporters/supported-exporters/Node.js/stackdriver-stats.md
@@ -9,7 +9,7 @@ logo: /images/logo_gcp_vertical_rgb.png
 - [Introduction](#introduction)
 - [Installing the exporter](#installing-the-exporter)
 - [Creating the exporters](#creating-the-exporter)
-- [Viewing your traces](#viewing-your-traces)
+- [Viewing your metrics](#viewing-your-metrics)
 - [References](#references)
 
 
@@ -54,8 +54,8 @@ var stats = new opencensus.Stats();
 stats.registerExporter(exporter);
 {{</highlight>}}
 
-## Viewing your traces
-Please visit [https://console.cloud.google.com/tracing/traces](https://console.cloud.google.com/tracing/traces)
+## Viewing your metrics
+Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
 
 ## References
 

--- a/content/guides/exporters/supported-exporters/Node.js/stackdriver-trace.md
+++ b/content/guides/exporters/supported-exporters/Node.js/stackdriver-trace.md
@@ -9,7 +9,6 @@ logo: /images/logo_gcp_vertical_rgb.png
 - [Introduction](#introduction)
 - [Installing the exporter](#installing-the-exporter)
 - [Creating the exporter](#creating-the-exporter)
-- [Viewing your metrics](#viewing-your-metrics)
 - [Viewing your traces](#viewing-your-traces)
 - [References](#references)
 


### PR DESCRIPTION
## Exporters Added
* Prometheus (Stats)
* Instana (Tracing)
* Jaeger (Tracing)
* Zipkin (Tracing)

Can be found at `/guides/supported-exporters/node.js/*`

## Node Exporter Fixes
* statsdriver-metrics: "Viewing your traces" -> "Viewing your metrics"
* statsdriver-tracing: removed unused table of contents entry