### PR TITLE
Standardize exporter card width

### DIFF
--- a/static/css/content.css
+++ b/static/css/content.css
@@ -175,10 +175,11 @@ section a .lang-card {
   -webkit-transition: all 200ms;
   -moz-transition: all 200ms;
   transition: all 200ms;
+
+  width: 200px;
 }
 
 .user-card-container {
-  width: 200px;
   height: 140px;
   position: relative;
 }


### PR DESCRIPTION
This addresses a small nitpick of mine on my original implementation of the exporter cards.

After making the vendor cards with a fixed width, it made it clear that the variable width of the exporter cards causes the overall appearance to look "wrong".

This PR sets a fixed width to exporter cards.

## Before
<img width="1241" alt="screen shot 2018-08-30 at 12 37 07 pm" src="https://user-images.githubusercontent.com/5974764/44874984-b68fb580-ac51-11e8-9741-08ed837678ad.png">

## After
<img width="1253" alt="screen shot 2018-08-30 at 12 36 58 pm" src="https://user-images.githubusercontent.com/5974764/44874981-b394c500-ac51-11e8-9129-74c90313830a.png">