### PR TITLE
content/quickstart: add aliases for node.js --> nodejs

### DIFF
--- a/content/quickstart/node.js/_index.md
+++ b/content/quickstart/node.js/_index.md
@@ -5,6 +5,7 @@ draft: false
 class: "resized-logo"
 url: quickstart/nodejs
 logo: /images/node-opencensus.png
+aliases: [/quickstart/node.js]
 ---
 
 In this quickstart, using OpenCensus Node, you will gain hands-on experience with:

--- a/content/quickstart/node.js/metrics.md
+++ b/content/quickstart/node.js/metrics.md
@@ -4,6 +4,7 @@ date: 2018-08-20T07:12:03-13:00
 draft: false
 class: "shadowed-image lightbox"
 url: quickstart/nodejs/metrics
+aliases: [/quickstart/node.js/metrics]
 ---
 
 - [Requirements](#requirements)

--- a/content/quickstart/node.js/tracing.md
+++ b/content/quickstart/node.js/tracing.md
@@ -4,6 +4,7 @@ date: 2018-07-22T20:29:06-07:00
 draft: false
 class: "shadowed-image lightbox"
 url: quickstart/nodejs/tracing
+aliases: [/quickstart/node.js/tracing]
 ---
 
 - [Requirements](#requirements)


### PR DESCRIPTION
Some links were broken after the node.js --> nodejs
rename. However, we had already advertised them,
hence provide those aliases.