### PR TITLE
content, layouts: add Erlang/Elixir owners

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,7 @@ class: "no-pagination no-top-border-header no-search max-text-width"
 {{<button class="btn-light" icon="true" href="/quickstart">}}Quickstart{{</button>}}
 
 ##### How can I use OpenCensus in my project?
-Our libraries support Go, Java, C++, Ruby, Erlang, Python, and PHP.
+Our libraries support Go, Java, C++, Ruby, Erlang/Elixir, Python, and PHP.
 
 Supported backends include Datadog, Instana, Jaeger, SignalFX, Stackdriver, and Zipkin. You can also [add support for other backends](/guides/exporters/custom-exporter/).
 

--- a/content/community/reporting-issues.md
+++ b/content/community/reporting-issues.md
@@ -16,7 +16,7 @@ Python|https://github.com/census-instrumentation/opencensus-python
 PHP|https://github.com/census-instrumentation/opencensus-php
 Node.js|https://github.com/census-instrumentation/opencensus-node
 C#|https://github.com/census-instrumentation/opencensus-csharp
-Erlang|https://github.com/census-instrumentation/opencensus-erlang
+Erlang/Elixir|https://github.com/census-instrumentation/opencensus-erlang
 
 For all other issues, please send an email to
 [census-developers@googlegroups.com](mailto:census-developers@googlegroups.com).

--- a/content/language-support/_index.md
+++ b/content/language-support/_index.md
@@ -15,6 +15,6 @@ Java|https://www.javadoc.io/doc/io.opencensus/opencensus-api/
 C++|https://github.com/census-instrumentation/opencensus-cpp
 Node.js|https://github.com/census-instrumentation/opencensus-node
 Ruby|https://www.rubydoc.info/gems/opencensus
-Erlang|https://hexdocs.pm/opencensus/
+Erlang/Elixir|https://hexdocs.pm/opencensus/
 Python|https://census-instrumentation.github.io/opencensus-python/trace/api/index.html
 PHP|https://packagist.org/packages/opencensus/opencensus

--- a/layouts/shortcodes/languages.html
+++ b/layouts/shortcodes/languages.html
@@ -21,13 +21,14 @@
       <td><a href="https://github.com/census-instrumentation/opencensus-cpp/blob/master/opencensus/stats/README.md">Supported</a></td>
       <td><a href="https://github.com/census-instrumentation/opencensus-cpp/blob/master/opencensus/trace/README.md">Supported</a></td>
       <td><a href="https://github.com/g-easy">Emil Mikulic</a> (Google)</td>
+      <td></td>
     </tr>
     <tr>
-      <td scope="row"><a href="https://github.com/census-instrumentation/opencensus-erlang">Erlang</a></td>
+      <td scope="row"><a href="https://github.com/census-instrumentation/opencensus-erlang">Erlang/Elixir</a></td>
       <td><a href="https://hexdocs.pm/opencensus">Supported</a></td>
       <td><a href="https://hexdocs.pm/opencensus">Supported</a></td>
-      <td></td>
-      <td></td>
+      <td><a href="https://github.com/tsloughter">Tristan Sloughter</a></td>
+      <td><a href="https://github.com/deadtrickster">Ilya Khaprov</a></td>
     </tr>
     <tr>
       <td scope="row"><a href="https://github.com/census-instrumentation/opencensus-go">Go</a></td>


### PR DESCRIPTION
Addresses requests that were sent via a forwarded email:
* Add @tsloughter and @deadtrickster as Erlang owners
* Replaces all references of "Erlang" with "Erlang/Elixir",
except for the headers that show the feature matrix
as "Erlang/Elixir" overflows its column tab.

Fixes #319