### PR TITLE
Update Jaeger UI endpoint

### DIFF
--- a/content/guides/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Go/Jaeger.md
@@ -66,7 +66,7 @@ func main() {
 {{</highlight>}}
 
 ## Viewing your traces
-Please visit the Jaeger UI endpoint [http://localhost:6831](http://localhost:6831)
+Please visit the Jaeger UI endpoint [http://localhost:16686](http://localhost:16686)
 
 ## Project link
 You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)


### PR DESCRIPTION
Update Jaeger UI port is: `16686`. Port `6831` is Jaeger Agent that accept `jaeger.thrift` over compact thrift protocol

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/census-instrumentation/opencensus-website/321)
<!-- Reviewable:end -->
