### PR TITLE
content/*: add Stackdriver metrics reporting period advisory

### DIFF
--- a/content/guides/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Go/Stackdriver.md
@@ -49,12 +49,17 @@ if err != nil {
 }
 {{</highlight>}}
 
+{{% notice warning %}}
+Stackdriver's minimum stats reporting period must be >= 60 seconds. Find out why at this [official Stackdriver advisory](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
+{{% /notice %}}
+
 {{<tabs Stats Tracing All>}}
 {{<highlight go>}}
 package main
 
 import (
 	"log"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats/view"
@@ -74,6 +79,7 @@ func main() {
 
 	// Register it as a metrics exporter
 	view.RegisterExporter(sd)
+	view.SetReportingPeriod(60 * time.Second)
 }
 {{</highlight>}}
 
@@ -109,6 +115,7 @@ package main
 
 import (
 	"log"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/stats/view"
@@ -129,6 +136,7 @@ func main() {
 
 	// Register it as a metrics exporter
 	view.RegisterExporter(sd)
+	view.SetReportingPeriod(60 * time.Second)
 
 	// Register it as a trace exporter
 	trace.RegisterExporter(sd)

--- a/content/guides/exporters/supported-exporters/Java/SignalFx.md
+++ b/content/guides/exporters/supported-exporters/Java/SignalFx.md
@@ -10,6 +10,7 @@ logo: /img/partners/signalFx_logo.svg
 
 - [Introduction](#introduction)
 - [Creating the exporter](#creating-the-exporter)
+- [References](#references)
 
 ## Introduction
 SignalFx is a real-time monitoring solution for cloud and distributed applications.
@@ -65,8 +66,8 @@ Instrument your application code with the following snippet:
 package io.opencensus.tutorial.signalfx;
 
 import io.opencensus.common.Duration;
-import io.opencensus.exporter.stats.stackdriver.SignalFxStatsConfiguration;
-import io.opencensus.exporter.stats.stackdriver.SignalFxStatsExporter;
+import io.opencensus.exporter.stats.signalfx.SignalFxStatsConfiguration;
+import io.opencensus.exporter.stats.signalfx.SignalFxStatsExporter;
 
 public class SignalFxTutorial {
     public static void main(String ...args) {
@@ -81,3 +82,9 @@ public class SignalFxTutorial {
     }
 }
 {{</highlight>}}
+
+## References
+
+Resource|URL
+---|---
+SignalFx stats exporter JavaDoc|https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-signalfx

--- a/content/guides/exporters/supported-exporters/Java/Stackdriver.md
+++ b/content/guides/exporters/supported-exporters/Java/Stackdriver.md
@@ -43,6 +43,10 @@ To create the exporters, you'll need to:
 * Use Maven setup your pom.xml file
 * Create the exporters in code
 
+{{% notice warning %}}
+Stackdriver's minimum stats reporting period must be >= 60 seconds. Find out why at this [official Stackdriver advisory](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
+{{% /notice %}}
+
 ### Import Packages
 Insert the following snippet in your `pom.xml`:
 ```xml

--- a/content/guides/exporters/supported-exporters/Node.js/stackdriver-stats.md
+++ b/content/guides/exporters/supported-exporters/Node.js/stackdriver-stats.md
@@ -42,6 +42,11 @@ export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
 {{</highlight>}}
 
 * Create the exporters in code
+
+{{% notice warning %}}
+Stackdriver's minimum stats reporting period must be >= 60 seconds. Find out why at this [official Stackdriver advisory](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
+{{% /notice %}}
+
 {{<highlight javascript>}}
 var opencensus = require('@opencensus/core');
 var stackdriver = require('@opencensus/exporter-stackdriver');

--- a/content/guides/gRPC/Go.md
+++ b/content/guides/gRPC/Go.md
@@ -330,6 +330,7 @@ func main() {
 	defer sd.Flush()
 	trace.RegisterExporter(sd)
 	view.RegisterExporter(sd)
+	view.SetReportingPeriod(60 * time.Second)
 	// For demo purposes let's always sample
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 

--- a/content/guides/integrations/memcached/Go.md
+++ b/content/guides/integrations/memcached/Go.md
@@ -121,7 +121,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to enable OpenCensus: %v", err)
 	}
-	defer flushFn()
+	defer func() {
+		// Wait for 60 seconds before exiting to allow metrics to be flushed
+		log.Println("Waiting for ~60s to allow metrics to be exported")
+		<-time.After(62 * time.Second)
+		flushFn()
+	}()
+
 
 	mc := memcache.New("localhost:11211")
 	log.SetFlags(0)
@@ -210,7 +216,7 @@ func enableOpenCensusTracingAndMetrics() (func(), error) {
 
 	// Register as a metrics exporter
 	view.RegisterExporter(sd)
-	view.SetReportingPeriod(50 * time.Millisecond)
+	view.SetReportingPeriod(60 * time.Second)
 	if err := view.Register(memcache.AllViews...); err != nil {
 		return nil, err
 	}

--- a/content/guides/integrations/redis/Go/gomodule_redigo.md
+++ b/content/guides/integrations/redis/Go/gomodule_redigo.md
@@ -166,7 +166,7 @@ func enableOpenCensus() (func(), error) {
 		return nil, err
 	}
 	view.RegisterExporter(sd)
-	view.SetReportingPeriod(50 * time.Millisecond)
+	view.SetReportingPeriod(60 * time.Second)
 
 	return sd.Flush, nil
 }
@@ -205,8 +205,9 @@ func main() {
 		log.Fatalf("Failed to enable OpenCensus exporting: %v", err)
 	}
 	defer func() {
-		// Wait for 2 seconds before exiting to allow metrics to be flushed
-		<-time.After(2 * time.Second)
+		// Wait for ~60 seconds before exiting to allow metrics to be flushed
+		log.Println("Waiting for ~60s to allow metrics to be exported")
+		<-time.After(62 * time.Second)
 		flushFn()
 	}()
 


### PR DESCRIPTION
Fixes #314

* Provide an advisory URL to official Stackdriver docs but
also change as many explicit usages of view.ReportingPeriod
with Stackdriver to >=60 seconds

* Also update an erraneous Java import path for the SignalFx
exporter