### PR TITLE
Migrate previous blog content

### DIFF
--- a/content/articles/_index.md
+++ b/content/articles/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Articles"
+date: 2018-09-13T15:10:47-07:00
+draft: false
+hidden: true
+---

--- a/content/articles/iot.md
+++ b/content/articles/iot.md
@@ -3,7 +3,8 @@ title: "OpenCensus for IoT"
 date: 2018-08-02
 draft: false
 weight: 3
-aliases: [/blog/iot]
+aliases: [/blog/iot, /blogs/iot]
+hidden: true
 ---
 
 ![](/images/IoT-GoogleCloud.jpg)

--- a/content/blogs/_index.md
+++ b/content/blogs/_index.md
@@ -7,4 +7,193 @@ aliases: [/blog]
 logo: /img/logo-sm.svg
 ---
 
-{{% children %}}
+##### August 9, 2018
+
+#### [OpenCensus for IoT](/articles/iot)
+
+Our application is a prototype which demonstrates how we can utilize OpenCensus for the observability in the IoT industry. With the service of metric collection and monitoring provided by OpenCensus, we’ll gain the insights into hardware and software performance across distributed IoT devices... [\[read more\]](/blogs/iot)
+
+---
+
+##### July 11, 2018
+
+#### [Monitoring HTTP Latency with OpenCensus and Stackdriver](https://medium.com/google-cloud/monitoring-http-latency-with-opencensus-and-stackdriver-bf561608e81a)
+
+This post will describe how to code your own monitoring probes, similar in function to Stackdriver uptime checks on Google Cloud. Code, configuration files, commands, and detailed instructions… [\[read more\]](https://medium.com/google-cloud/monitoring-http-latency-with-opencensus-and-stackdriver-bf561608e81a)
+
+---
+
+##### June 13, 2018
+
+#### [Redis clients instrumented by OpenCensus in Java and Go](https://medium.com/@orijtech/redis-clients-instrumented-by-opencensus-in-java-and-go-402470d92c5c)
+
+In this post we’ll examine Redis clients instrumented with OpenCensus in Java and Go, and apply them directly to use Redis in a media search service to alleviate costs, throttling, load… [\[read more\]](https://medium.com/@orijtech/redis-clients-instrumented-by-opencensus-in-java-and-go-402470d92c5c)
+
+---
+
+##### June 13, 2018
+
+#### [Microsoft joins the OpenCensus project](https://open.microsoft.com/2018/06/13/microsoft-joins-the-opencensus-project/)
+
+We are happy to announce that Microsoft is joining the open source OpenCensus project, and they are excited to help it achieve the goal of “a single distribution of libraries for metrics and distributed tracing”… [\[read more\]](https://open.microsoft.com/2018/06/13/microsoft-joins-the-opencensus-project/)
+
+---
+
+##### June 12, 2018
+
+#### [Hit the Ground Running with Distributed Tracing Core Concepts](https://medium.com/nikeengineering/hit-the-ground-running-with-distributed-tracing-core-concepts-ff5ad47c7058)
+
+Wondering what Distributed Tracing is, or having trouble making it work? Understanding its core concepts is a critical first step. Monolithic service architectures for large backend applications… [\[read more\]](https://medium.com/nikeengineering/hit-the-ground-running-with-distributed-tracing-core-concepts-ff5ad47c7058)
+
+---
+
+##### May 13, 2018
+
+#### [OpenCensus for Go gRPC developers](https://medium.com/@orijtech/opencensus-for-go-grpc-developers-7f3ee1ac3d6d)
+
+In this tutorial, we’ll examine how to use OpenCensus in your gRPC projects in the Go programming language for observability both into your server and then client! We’ll then examine how we can integrate with… [\[read more\]](https://medium.com/@orijtech/opencensus-for-go-grpc-developers-7f3ee1ac3d6d)
+
+---
+
+##### May 7, 2018
+
+#### [OpenCensus’s journey ahead: platforms and languages](https://opensource.googleblog.com/2018/05/opencensus-journey-ahead-part-1.html)
+
+We recently blogged about the value of OpenCensus and how Google uses Census internally. Today, we want to share more about our long-term vision for OpenCensus. The goal of OpenCensus is to… [\[read more\]](https://opensource.googleblog.com/2018/05/opencensus-journey-ahead-part-1.html)
+
+---
+
+##### May 4, 2018
+
+#### [Practical and Useful Latency Analysis using Istio and OpenCenus](https://www.youtube.com/watch?v=ME-EhOKqFOY)
+
+Want to view more sessions and keep the conversations going? Join us for KubeCon + CloudNativeCon North America in Seattle, December 11 - 13, 2018 [\[read more\]](https://www.youtube.com/watch?v=ME-EhOKqFOY)
+
+---
+
+##### April 30, 2018
+
+#### [Memcached clients instrumented with OpenCensus in Go and Python](https://medium.com/@orijtech/memcached-clients-instrumented-with-opencensus-in-go-and-python-dacbd01b269c)
+
+One of the most used server caching and scaling technologies is Memcached [http://memcached.org/](http://memcached.org/) Memcached is a high performance, free and open… [\[read more\]](https://medium.com/@orijtech/memcached-clients-instrumented-with-opencensus-in-go-and-python-dacbd01b269c)
+
+---
+
+##### April 18, 2018
+
+#### [“Hello, world!” for web servers in Go with OpenCensus](https://medium.com/@orijtech/hello-world-for-web-servers-in-go-with-opencensus-29955b3f02c6)
+
+In this post, we’ll examine how you can minimally add distributed tracing and monitoring to your web server written in Go, with OpenCensus [https://opencensus.io](https://opencensus.io) [\[read more\]](https://medium.com/@orijtech/hello-world-for-web-servers-in-go-with-opencensus-29955b3f02c6)
+
+---
+
+##### April 4, 2018
+
+#### [Twitter - Bob Quillin](https://twitter.com/bobquillin/status/981571739720167425)
+
+Great OpenCensus 101 explaining its role in microservices stats collection, distributed tracing, and support for multiple backends [https://storage.googleapis.com/opencensusio/OpenCensusVideo.mp4](https://storage.googleapis.com/opencensusio/OpenCensusVideo.mp4) [\[read more\]](https://twitter.com/bobquillin/status/981571739720167425)
+
+---
+
+
+##### April 3, 2018
+
+#### [Tracing all the Fn things with OpenCensus](https://medium.com/fnproject/tracing-all-the-fn-things-with-opencensus-e579b268aeca)
+
+The Fn Project has decided to join all the other cool kids and become obsessed with tracing. Congratulations people, your meetup talks did not fall entirely on deaf ears. We’re really excited about moving all of our metrics… [\[read more\]](https://medium.com/fnproject/tracing-all-the-fn-things-with-opencensus-e579b268aeca)
+
+---
+
+##### April 3, 2018
+
+#### [Twitter - Chad Arimura](https://twitter.com/chadarimura/status/981319453282467840)
+
+“Tracing all the Fn things with OpenCensus” by @rdallman10 [https://medium.com/fnproject/tracing-all-the-fn-things-with-opencensus-e579b268aeca](https://medium.com/fnproject/tracing-all-the-fn-things-with-opencensus-e579b268aeca) … #serverless #golang cc @opencensusio @CloudNativeFdn [\[read more\]](https://medium.com/fnproject/tracing-all-the-fn-things-with-opencensus-e579b268aeca)
+
+---
+
+##### April 3, 2018
+
+#### [Twitter - Bruce MacVarish](https://twitter.com/brucemacv/status/981324918330744833)
+
+We’re really excited about moving all of our metrics and trace reporting to OpenCensus. #serverless #cloudnative @OracleIaaS [\[read more\]](https://twitter.com/brucemacv/status/981324918330744833)
+
+---
+
+##### March 20, 2018
+
+#### [Measure Once — Export Anywhere: OpenCensus in the wild](https://blog.doit-intl.com/measure-once-export-anywhere-opencensus-in-the-wild-61724f44eb00)
+
+A few months ago, Google has announced OpenCensus, a vendor-neutral open source library for telemetry and tracing collection. [\[read more\]](https://blog.doit-intl.com/measure-once-export-anywhere-opencensus-in-the-wild-61724f44eb00)
+
+---
+
+##### March 14, 2018
+
+#### [OpenCensus with Morgan McLean and JBD](https://www.gcppodcast.com/post/episode-118-opencensus-with-morgan-mclean-and-jbd/)
+
+Product Manager Morgan McLean and Software Engineer JBD join Melanie and Mark this week to discuss the new open source project OpenCensus, a single distribution of libraries for metrics and… [\[read more\]](https://www.gcppodcast.com/post/episode-118-opencensus-with-morgan-mclean-and-jbd/)
+
+---
+
+##### March 13, 2018
+
+#### [The value of OpenCensus](https://opensource.googleblog.com/2018/03/the-value-of-opencensus.html)
+
+This post is the second in a series about OpenCensus. You can find the first post here. Early this year we open sourced OpenCensus, a distributed tracing and stats instrumentation framework. [\[read more\]](https://opensource.googleblog.com/2018/03/the-value-of-opencensus.html)
+
+---
+
+##### March 12, 2018
+
+#### [OpenCensus Tracing w/ Stackdriver](https://medium.com/google-cloud/opencensus-tracing-w-stackdriver-a079fae52499)
+
+A customer’s engineers asked how they could combine OpenCensus tracing w/ App Engine Flexible in their Java apps and surface the results in Stackdriver. [\[read more\]](https://medium.com/google-cloud/opencensus-tracing-w-stackdriver-a079fae52499)
+
+---
+
+##### March 8, 2018
+
+#### [Cloud Spanner, instrumented by OpenCensus and exported to Stackdriver](https://medium.com/@orijtech/cloud-spanner-instrumented-by-opencensus-and-exported-to-stackdriver-6ed61ed6ab4e)
+
+In this post, we’ll explore the power of OpenCensus’ exporters, using the Google Cloud Spanner package for both the Go and Java programming languages. [\[read more\]](https://medium.com/@orijtech/cloud-spanner-instrumented-by-opencensus-and-exported-to-stackdriver-6ed61ed6ab4e)
+
+---
+
+##### March 7, 2018
+
+#### [How Google uses Census internally](https://opensource.googleblog.com/2018/03/how-google-uses-opencensus-internally.html)
+
+This post is the first in a series about OpenCensus, a set of open source instrumentation libraries based on what we use inside Google. This series will cover the benefits of OpenCensus for developers and vendors… [\[read more\]](https://opensource.googleblog.com/2018/03/how-google-uses-opencensus-internally.html)
+
+---
+
+##### February 18, 2018
+
+#### [What is distributed tracing. Zoom on opencensus and opentracing](https://gianarb.it/blog/what-is-distributed-tracing-opentracing-opencensus)
+
+A few months ago I started to actively study, support and use opentracing and more in general the distributed tracing topic. In this article, I will share something about… [\[read more\]](https://gianarb.it/blog/what-is-distributed-tracing-opentracing-opencensus)
+
+---
+
+##### January 23, 2018
+
+#### [OpenCensus — towards harmonizing your Instrumentation](http://dieswaytoofast.blogspot.com/2018/01/opencensustowards-harmonizing-your.html)
+
+You’ve really gotten into this whole Observability thing, and have started plugging Prometheus into, well, everything that doesn’t already have it. [\[read more\]](http://dieswaytoofast.blogspot.com/2018/01/opencensustowards-harmonizing-your.html)
+
+---
+
+##### January 18, 2018
+
+#### [OpenCensus with Prometheus and Kubernetes](https://kausal.co/blog/opencensus-prometheus-kausal/)
+
+Yesterday, Google announced OpenCensus, an instrumentation framework for monitoring and tracing. It comes with a set of client libraries for Golang and Java, with more to come. [\[read more\]](https://kausal.co/blog/opencensus-prometheus-kausal/)
+
+---
+
+##### January 17, 2018
+
+#### [OpenCensus: A Stats Collection and Distributed Tracing Framework](https://opensource.googleblog.com/2018/01/opencensus.html)
+
+Today we’re pleased to announce the release of OpenCensus, a vendor-neutral open source library for metric collection and tracing. [\[read more\]](https://opensource.googleblog.com/2018/01/opencensus.html)


### PR DESCRIPTION
Fixes #324

This PR does a few things:

1. Populates `/blogs` with content from the [previous iteration](https://github.com/census-instrumentation/opencensus-website/blob/701f94daaa6358b9551ab2da40298e8e89bf5a24/content/blog.md). It is now an index of blog listings.
2. Adds "Internet of Things" to the blog index. I saw that the file was initially edited on August 9th, so I dated the blog entry as August 9th.
3. Because we have many entries in the blog index, but the menu item `blog` has only one child entry (which is Internet of Things), I have removed the child entry and `blog` is no longer a parent element. Users can still access the "Internet of Things" blog from the blog index page.

Before (regarding 3):
<img width="219" alt="screen shot 2018-09-13 at 3 17 13 pm" src="https://user-images.githubusercontent.com/5974764/45519071-81628780-b768-11e8-9507-ce743d95a77f.png">

After:
<img width="119" alt="screen shot 2018-09-13 at 3 17 07 pm" src="https://user-images.githubusercontent.com/5974764/45519087-8fb0a380-b768-11e8-9b15-d9ec7cefff22.png">
