### PR TITLE
Add OpenCensus logo to Articles

### DIFF
--- a/content/articles/iot.md
+++ b/content/articles/iot.md
@@ -5,6 +5,7 @@ draft: false
 weight: 3
 aliases: [/blog/iot, /blogs/iot]
 hidden: true
+logo: /img/logo-sm.svg
 ---
 
 ![](/images/IoT-GoogleCloud.jpg)


### PR DESCRIPTION
Fixes #329 

Preview:
<img width="1263" alt="screen shot 2018-09-14 at 10 01 43 am" src="https://user-images.githubusercontent.com/5974764/45564467-58440480-b805-11e8-84cb-0299bf414443.png">
