### PR TITLE
content: fix Node.js missing and related info

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -16,7 +16,7 @@ class: "no-pagination no-top-border-header no-search max-text-width"
 {{<button class="btn-light" icon="true" href="/quickstart">}}Quickstart{{</button>}}
 
 ##### How can I use OpenCensus in my project?
-Our libraries support Go, Java, C++, Ruby, Erlang/Elixir, Python, and PHP.
+Our libraries support Go, Java, Node.js, C++, Ruby, Erlang/Elixir, Python, and PHP.
 
 Supported backends include Datadog, Instana, Jaeger, SignalFX, Stackdriver, and Zipkin. You can also [add support for other backends](/guides/exporters/custom-exporter/).
 

--- a/content/guides/exporters/_index.md
+++ b/content/guides/exporters/_index.md
@@ -16,7 +16,9 @@ Need a refresher on Exporters? [Click here](/core-concepts/exporters)
 {{<card-exporter target-url="supported-exporters/go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
 {{<card-exporter target-url="supported-exporters/java" src="/images/java-icon.png" lang="Java" tracing="true" stats="true">}}
 {{<card-exporter target-url="supported-exporters/python" src="/images/python-icon.png" lang="Python" tracing="true">}}
+{{<card-exporter target-url="supported-exporters/node.js" src="/images/nodejs.png" lang="Node.js" tracing="true" stats="true">}}
 
 **Writing a Custom Exporter**
 {{<card-exporter target-url="custom-exporter/go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
 {{<card-exporter target-url="custom-exporter/java" src="/images/java-icon.png" lang="Java" tracing="true">}}
+{{<card-exporter target-url="custom-exporter/node.js" src="/images/nodejs.png" lang="Node.js" tracing="true" stats="true">}}

--- a/content/guides/exporters/custom-exporter/_index.md
+++ b/content/guides/exporters/custom-exporter/_index.md
@@ -20,4 +20,4 @@ However, this guide is to enable anyone and any vendor to implement their custom
 
 {{<card-exporter target-url="go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
 {{<card-exporter target-url="java" src="/images/java-icon.png" lang="Java" tracing="true">}}
-{{<card-exporter target-url="node.js" src="/images/nodejs.png" lang="Node" tracing="true" stats="true">}}
+{{<card-exporter target-url="node.js" src="/images/nodejs.png" lang="Node.js" tracing="true" stats="true">}}

--- a/layouts/shortcodes/quickstart-list.html
+++ b/layouts/shortcodes/quickstart-list.html
@@ -55,6 +55,12 @@ Tracing
 </div>
 <a
   class="btn btn-info"
+  onclick="location.href='nodejs/metrics'"
+>
+Metrics
+</a>
+<a
+  class="btn btn-info"
   onclick="location.href='nodejs/tracing'"
 >
 Tracing


### PR DESCRIPTION
* Reported offline via direct message, the front page is missing
"Node.js" as a supported language

* Noticed while combing through:
+ supported exporters page is missing Node.js' metrics card
+ custom exporters page uses "Node" as name, it should be Node.js
+ quickstart-list is missing "Metrics" for Node.js

Fixes #332