### PR TITLE
quickstart/node.js: fix buggy Node.js URLs

### DIFF
--- a/content/quickstart/nodejs/_index.md
+++ b/content/quickstart/nodejs/_index.md
@@ -3,7 +3,6 @@ title: "Node.js"
 date: 2018-07-16T14:29:03-07:00
 draft: false
 class: "resized-logo"
-url: quickstart/nodejs
 logo: /images/node-opencensus.png
 aliases: [/quickstart/node.js]
 ---

--- a/content/quickstart/nodejs/metrics.md
+++ b/content/quickstart/nodejs/metrics.md
@@ -3,7 +3,6 @@ title: "Metrics"
 date: 2018-08-20T07:12:03-13:00
 draft: false
 class: "shadowed-image lightbox"
-url: quickstart/nodejs/metrics
 aliases: [/quickstart/node.js/metrics]
 ---
 

--- a/content/quickstart/nodejs/tracing.md
+++ b/content/quickstart/nodejs/tracing.md
@@ -3,7 +3,6 @@ title: "Tracing"
 date: 2018-07-22T20:29:06-07:00
 draft: false
 class: "shadowed-image lightbox"
-url: quickstart/nodejs/tracing
 aliases: [/quickstart/node.js/tracing]
 ---
 


### PR DESCRIPTION
The URLs of these pages had been forced
with the Hugo/Markdown meta-tag 'url' hence
the bad doubly included URLs

Topic|Bad relative URL
---|---
Metrics|/quickstart/node.js/quickstart/nodejs/metrics
Tracing|/quickstart/node.js/quickstart/nodejs/tracing

yet they should be

Topic|Good relative URL
---|---
Metrics|/quickstart/nodejs/metrics
Tracing|/quickstart/nodejs/tracing

but also for some reason the `Node.js` directory was ill-named
as `Node.js` instead of like the others being in lower case
and avoiding the `.js` suffix, for which we already have aliases.

This change fixes those problems mentioned above.

Fixes #364