### PR TITLE
quickstart/go/tracing: fix example code formatting

### DIFF
--- a/content/quickstart/go/tracing.md
+++ b/content/quickstart/go/tracing.md
@@ -331,7 +331,7 @@ func readEvaluateProcess(br *bufio.Reader) error {
 	ctx, span := trace.StartSpan(context.Background(), "repl")
 	defer span.End()
 
-        _, line, err := readLine(ctx, br)
+	_, line, err := readLine(ctx, br)
 	if err != nil {
 		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
 		return err
@@ -408,7 +408,7 @@ func readEvaluateProcess(br *bufio.Reader) error {
 	ctx, span := trace.StartSpan(context.Background(), "repl")
 	defer span.End()
 
-        _, line, err := readLine(ctx, br)
+	_, line, err := readLine(ctx, br)
 	if err != nil {
 		span.SetStatus(trace.Status{Code: trace.StatusCodeUnknown, Message: err.Error()})
 		return err


### PR DESCRIPTION
This is a small follow up to https://github.com/census-instrumentation/opencensus-website/issues/368 and its fix https://github.com/census-instrumentation/opencensus-website/pull/369.

This fixes the following formatting issue:

![](https://i.imgur.com/K6ikv29.png)