### PR TITLE
content/feature-matrix: add a space between SD trace and stats exporters.

### DIFF
--- a/layouts/shortcodes/feature-matrix.html
+++ b/layouts/shortcodes/feature-matrix.html
@@ -76,7 +76,7 @@
 	  <td data-label="java"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr> <abbr title="Stats Exporter" class="stats-exporter teal white-text">S</abbr></td>
 		<td data-label="nodejs"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr></td>
 		<td data-label="php">–</td>
-	  <td data-label="python"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr><abbr title="Stats Exporter" class="stats-exporter teal white-text">S</abbr></td>
+	  <td data-label="python"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr> <abbr title="Stats Exporter" class="stats-exporter teal white-text">S</abbr></td>
 		<td data-label="ruby">–</td>
 	</tr>
 	<tr>


### PR DESCRIPTION
![python-exporters](https://user-images.githubusercontent.com/10536136/46684664-5d983300-cba8-11e8-8163-b3c0a5d14a59.png)

There should be a space between "T" and "S" for Stackdriver exporters.