### PR TITLE
content/index: Add Honeycomb.io to index page.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -64,3 +64,4 @@ OpenCensus originates from Google, where a set of libraries called Census were u
 {{<card-vendor href="https://prometheus.io/" src="/img/partners/prometheus_logo.svg">}}
 {{<card-vendor href="https://www.instana.com/" src="/img/partners/instana_logo.svg">}}
 {{<card-vendor href="https://omnition.io/" src="/img/partners/omnition_logo.svg">}}
+{{<card-vendor href="https://www.honeycomb.io/" src="/img/partners/honeycomb_logo.svg">}}


### PR DESCRIPTION
Honeycomb.io is on https://opencensus.io/introduction/ but not on the index page.