### PR TITLE
Fix import naming issue in example code

### DIFF
--- a/content/guides/exporters/supported-exporters/Node.js/Jaeger.md
+++ b/content/guides/exporters/supported-exporters/Node.js/Jaeger.md
@@ -49,7 +49,7 @@ var jaegerOptions = {
   port: 6832,
   tags: [{key: 'opencensus-exporter-jeager', value: '0.0.1'}],
   bufferTimeout: 10, // time in milliseconds
-  logger: core.logger('debug'),
+  logger: core.logger.logger('debug'),
   maxPacketSize: 1000
 };
 


### PR DESCRIPTION
This fix is necessary because in https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/index.ts#L54 we have 

```
import * as logger from './common/console-logger';
export {logger};
```

this imports the entire console-logger module is imported under the namespace `logger`.  Then we export that.

Therefore, to gain access to this function https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/common/console-logger.ts#L109 we end up needing to use `core.logger.logger`.

I'm open to this also being fixed by fixing the export (see https://github.com/census-instrumentation/opencensus-node/pull/146), as it seems a bit unintuitive.