### PR TITLE
feature-matrix: add a missing td.

### DIFF
--- a/layouts/shortcodes/feature-matrix.html
+++ b/layouts/shortcodes/feature-matrix.html
@@ -112,6 +112,7 @@
 	</tr>
 	<tr>
 	  <td>Honeycomb</td>
+	  <td data-label="csharp">–</td>
 	  <td data-label="cpp">–</td>
 	  <td data-label="erlang">–</td>
 	  <td data-label="golang"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr></td>


### PR DESCRIPTION
![feature-matrix-1](https://user-images.githubusercontent.com/10536136/47322869-6c520180-d60e-11e8-8d2e-12895cef65d9.png)

Note that td C# is missing for row Honeycomb.