### PR TITLE
guides/custom-exporter/cpp: relocate trace exporter guide

### DIFF
--- a/content/guides/exporters/custom-exporter/Cpp/Tracing.md
+++ b/content/guides/exporters/custom-exporter/Cpp/Tracing.md
@@ -1,5 +1,5 @@
 ---
-title: "Exporters"
+title: "Trace exporter"
 date: 2018-10-22T17:31:12-07:00
 draft: false
 class: "shadowed-image lightbox"

--- a/content/guides/exporters/custom-exporter/Cpp/_index.md
+++ b/content/guides/exporters/custom-exporter/Cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "C++"
+draft: false
+weight: 3
+class: "resized-logo"
+logo: /images/cpp-opencensus.png
+---
+
+#### Introduction
+
+As already introduced in section [Core Concepts/Exporters](/core-concepts/exporters/), exporters are the vendor agnostic mechanism that OpenCensus provides to allow you to process span data and metrics beofre sending them to any of your trace or metrics backends.
+
+You'll learn how to create the following exporters:
+
+{{% children %}}

--- a/content/guides/exporters/custom-exporter/_index.md
+++ b/content/guides/exporters/custom-exporter/_index.md
@@ -18,6 +18,7 @@ However, this guide is to enable anyone and any vendor to implement their custom
 
 <abbr class="stats-exporter teal white-text">S</abbr> Stats guide available
 
+{{<card-exporter target-url="cpp" src="/images/cpp.png" lang="C++" tracing="true" stats="true">}}
 {{<card-exporter target-url="go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
 {{<card-exporter target-url="java" src="/images/java-icon.png" lang="Java" tracing="true">}}
 {{<card-exporter target-url="node.js" src="/images/nodejs.png" lang="Node.js" tracing="true" stats="true">}}


### PR DESCRIPTION
Move the trace exporter guide to the right location that is
under "guides/exporters/custom-exporters/cpp"
but also added the necessary "_index.md" and logo entries.