### PR TITLE
Invert survey button colors

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -43,7 +43,8 @@ a.btn.btn-light.survey-button {
 
 a.btn.btn-light.survey-button {
   margin-bottom: 0;
-  color: #75af00;
+  color: #fff;
+  background: #75af00;
   border: 1px solid #75af00;
 }
 


### PR DESCRIPTION
As per offline feedback, the survey button colors have been inverted in an effort to catch the user's eye.

This applies to both desktop and mobile buttons.

New in this PR:
<img width="796" alt="screen shot 2018-10-31 at 11 56 55 am" src="https://user-images.githubusercontent.com/5974764/47811936-3eeb0f00-dd04-11e8-9809-2ff88c930c04.png">

Currently deployed:
<img width="775" alt="screen shot 2018-10-31 at 11 58 24 am" src="https://user-images.githubusercontent.com/5974764/47811965-532f0c00-dd04-11e8-9473-449974839902.png">
