### PR TITLE
content/*/supported-exporters/*: use {{% children %}} listing

### DIFF
--- a/content/guides/exporters/supported-exporters/Go/_index.md
+++ b/content/guides/exporters/supported-exporters/Go/_index.md
@@ -10,11 +10,4 @@ logo: /images/gopher.png
 
 OpenCensus Go provides support for various exporters like:
 
-* [AWS X-Ray](/supported-exporters/go/xray/)
-* [Azure Monitor](/supported-exporters/go/applicationinsights/)
-* [Google Stackdriver Tracing and Monitoring](/supported-exporters/go/stackdriver/)
-* [DataDog APM and Tracing](/supported-exporters/go/datadog/)
-* [Prometheus Monitoring](/supported-exporters/go/prometheus/)
-* [Zipkin](/supported-exporters/go/zipkin)
-* [Jaeger](/supported-exporters/go/jaeger)
-* [Honeycomb](/supported-exporters/go/honeycomb)
+{{% children %}}

--- a/content/guides/exporters/supported-exporters/Java/_index.md
+++ b/content/guides/exporters/supported-exporters/Java/_index.md
@@ -15,10 +15,4 @@ For full reference, you can visit:
 
 OpenCensus Java provides support for various exporters like:
 
-* [Google Stackdriver Tracing and Monitoring](/supported-exporters/java/stackdriver)
-* [Instana](/supported-exporters/java/instana)
-* [Prometheus Monitoring](/supported-exporters/java/prometheus)
-* [Zipkin](/supported-exporters/java/zipkin)
-* [Jaeger](/supported-exporters/java/jaeger)
-* [SignalFX](/supported-exporters/java/signalfx)
-* [Logging](/supported-exporters/java/logging)
+{{% children %}}

--- a/content/guides/exporters/supported-exporters/Java/stackdriver-stats.md
+++ b/content/guides/exporters/supported-exporters/Java/stackdriver-stats.md
@@ -24,7 +24,8 @@ Stackdriver collects metrics, events, and metadata from Google Cloud Platform, A
 
 Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more.
 
-OpenCensus Java has support for this exporter available through packages:
+OpenCensus Java has support for this exporter available through package:
+
 * Exporters/Stats [io.opencensus.exporter.stats.stackdriver](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-stackdriver)
 
 ## Creating the exporters

--- a/content/guides/exporters/supported-exporters/Python/_index.md
+++ b/content/guides/exporters/supported-exporters/Python/_index.md
@@ -10,7 +10,4 @@ logo: /images/python-opencensus.png
 
 OpenCensus Python provides support for various exporters like:
 
-* [Azure Monitor](/supported-exporters/python/applicationinsights)
-* [Google Stackdriver Tracing](/supported-exporters/python/stackdriver/)
-* [Jaeger](/supported-exporters/python/jaeger)
-* [Zipkin](/supported-exporters/python/zipkin)
+{{% children %}}


### PR DESCRIPTION
A bunch of the listings on */supported-exporters/*/_index.md
hard coded listings but that means that if we change or remove
any item, we'll have stale data. Also some URLs were broken.
This change fixes that fragility by using {{% children %}}
to list out available exporters.