### PR TITLE
exporters: add back files that were removed by git rebase

### DIFF
--- a/content/exporters/custom-exporter/Cpp/Tracing.md
+++ b/content/exporters/custom-exporter/Cpp/Tracing.md
@@ -1,0 +1,111 @@
+---
+title: "Trace exporter"
+date: 2018-10-22T17:31:12-07:00
+draft: false
+class: "shadowed-image lightbox"
+---
+
+In this quickstart, we'll learn how to write a custom exporter for tracing.
+
+## Requirements
+- A C++ compiler: g++ or clang
+- [Bazel](https://bazel.build/)
+
+## Brief overview
+By the end of this tutorial, we would have done these two things using OpenCensus:
+
+1. Write a custom exporter for tracing.
+2. Show how to use this exporter in an example program.
+
+## Getting started
+The exporter has two components:
+- An API that lets the user register it.
+- An internal implementation that implements the `Handler` interface.
+
+Let's put the API in `latency_exporter.h`:
+
+```cpp
+class LatencyExporter {
+ public:
+  LatencyExporter() = delete;
+  static void Register();
+};
+```
+
+And the implementation in `latency_exporter.cc`:
+
+```cpp
+#include "latency_exporter.h"
+
+#include <iostream>
+#include <vector>
+
+#include "absl/memory/memory.h"
+#include "opencensus/trace/exporter/span_data.h"
+#include "opencensus/trace/exporter/span_exporter.h"
+
+namespace {
+
+class Handler : public ::opencensus::trace::exporter::SpanExporter::Handler {
+ public:
+  void Export(const std::vector<::opencensus::trace::exporter::SpanData>& spans)
+      override {
+    // Export each span we were given.
+    for (const auto& span : spans) {
+      std::cout << "Span \"" << span.name() << "\" took "
+                << (span.end_time() - span.start_time()) << ".\n";
+    }
+  }
+};
+
+}  // namespace
+
+// static
+void LatencyExporter::Register() {
+  ::opencensus::trace::exporter::SpanExporter::RegisterHandler(
+      absl::make_unique<Handler>());
+}
+```
+
+Add a `cc_library` target to the BUILD file:
+
+```python
+cc_library(
+    name = "latency_exporter",
+    srcs = ["latency_exporter.cc"],
+    hdrs = ["latency_exporter.h"],
+    deps = [
+        "@com_google_absl//absl/memory",
+        "@io_opencensus_cpp//opencensus/trace",
+    ],
+)
+```
+
+## Exercise
+
+Adapt the [tracing quickstart](../tracing/) to use this exporter:
+
+* Add our new `":latency_exporter"` library as a dependency.
+
+* Add a `#include "latency_exporter.h"`.
+
+* Call `LatencyExporter::Register();` in `main()`.
+
+Every five seconds, the exporter will produce output like:
+
+```
+Span "readLine" took 1.862484838s.
+Span "processLine" took 37.702us.
+Span "repl" took 1.862748259s.
+```
+
+## References
+
+A good reference is
+[opencensus/exporters/trace/stdout/](https://github.com/census-instrumentation/opencensus-cpp/tree/master/opencensus/exporters/trace/stdout)
+which implements a simple exporter.
+
+Resource|URL
+---|---
+OpenCensus C++|https://github.com/census-instrumentation/opencensus-cpp
+Bazel build system|https://bazel.build/

--- a/content/exporters/custom-exporter/Cpp/_index.md
+++ b/content/exporters/custom-exporter/Cpp/_index.md
@@ -1,0 +1,15 @@
+---
+title: "C++"
+draft: false
+weight: 3
+class: "resized-logo"
+logo: /images/cpp-opencensus.png
+---
+
+#### Introduction
+
+As already introduced in section [Core Concepts/Exporters](/core-concepts/exporters/), exporters are the vendor agnostic mechanism that OpenCensus provides to allow you to process span data and metrics beofre sending them to any of your trace or metrics backends.
+
+You'll learn how to create the following exporters:
+
+{{% children %}}

--- a/content/exporters/custom-exporter/Go/Metrics.md
+++ b/content/exporters/custom-exporter/Go/Metrics.md
@@ -1,0 +1,160 @@
+---
+title: "Metrics exporter"
+draft: false
+weight: 3
+aliases: [/custom_exporter/go/metrics]
+---
+
+- [Introduction](#introduction)
+- [Implementation](#implementation)
+- [Runnable example](#runnable-example)
+- [Notes](#notes)
+- [References](#references)
+
+## Introduction
+A metrics/stats exporter must conform to the interface [stats/view.Exporter](https://godoc.org/go.opencensus.io/stats/view#Exporter) which for purposes of brevity is:
+
+```go
+import "go.opencensus.io/stats/view"
+
+type Exporter interface {
+    ExportView(vd *view.Data)
+}
+```
+
+whose sole method `ExportView` is the one in which you'll process and translate [View Data](https://godoc.org/go.opencensus.io/stats/view#Data) into the data that your metrics backend accepts.
+
+## Implementation
+
+For example, let's create a custom metrics/stats exporter that will print view data to standard output.
+
+```go
+import (
+	"context"
+	"log"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+type customMetricsExporter struct{}
+
+func (ce *customMetricsExporter) ExportView(vd *view.Data) {
+	log.Printf("vd.View: %+v\n%#v\n", vd.View, vd.Rows)
+	for i, row := range vd.Rows {
+		log.Printf("\tRow: %#d: %#v\n", i, row)
+	}
+        log.Printf("StartTime: %s EndTime: %s\n\n", vd.Start.Round(0), vd.End.Round(0))
+}
+```
+
+and then afterwards we must ensure that we invoke `view.RegisterExporter` with an instance of the exporter, like this:
+
+```go
+view.RegisterExporter(new(customMetricsExporter))
+```
+
+## Runnable example
+and now to test it out as we would in a typically linked program
+
+```go
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+type customMetricsExporter struct{}
+
+func (ce *customMetricsExporter) ExportView(vd *view.Data) {
+	log.Printf("vd.View: %+v\n%#v\n", vd.View, vd.Rows)
+	for i, row := range vd.Rows {
+		log.Printf("\tRow: %#d: %#v\n", i, row)
+	}
+        log.Printf("StartTime: %s EndTime: %s\n\n", vd.Start.Round(0), vd.End.Round(0))
+}
+
+func main() {
+	log.SetFlags(0)
+	// We need to have registered at least one view
+	if err := view.Register(loopCountView); err != nil {
+		log.Fatalf("Failed to register loopCountView: %v", err)
+	}
+
+	// Please remember to register your exporter
+	// so that it can receive exported view Data.
+	view.RegisterExporter(new(customMetricsExporter))
+
+	// For demo purposes we'll use a very short view data reporting
+	// period so that we can examine the stats send to our exporter, quickly.
+	view.SetReportingPeriod(100 * time.Millisecond)
+
+	ctx, _ := tag.New(context.Background(), tag.Upsert(keyMethod, "main"))
+	for i := int64(0); i < 5; i++ {
+		stats.Record(ctx, mLoops.M(i))
+		<-time.After(10 * time.Millisecond)
+	}
+	<-time.After(500 * time.Millisecond)
+}
+
+// The measure and view to be used for demo purposes
+var keyMethod, _ = tag.NewKey("method")
+var mLoops = stats.Int64("demo/loop_iterations", "The number of loop iterations", "1")
+var loopCountView = &view.View{
+	Measure: mLoops, Name: "demo/loop_iterations",
+	Description: "Number of loop iterations",
+	Aggregation: view.Count(),
+	TagKeys:     []tag.Key{keyMethod},
+}
+```
+
+will print out something like this:
+```shell
+vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKeys:[{name:method}] Measure:0xc00000c030 Aggregation:0x118d8e0}
+[]*view.Row{(*view.Row)(0xc0000762a0)}
+	Row: 0: &view.Row{Tags:[]tag.Tag{tag.Tag{Key:tag.Key{name:"method"}, Value:"main"}}, Data:(*view.CountData)(0xc00001a098)}
+StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.096631 -0700 PDT
+
+vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKeys:[{name:method}] Measure:0xc00000c030 Aggregation:0x118d8e0}
+[]*view.Row{(*view.Row)(0xc000108000)}
+	Row: 0: &view.Row{Tags:[]tag.Tag{tag.Tag{Key:tag.Key{name:"method"}, Value:"main"}}, Data:(*view.CountData)(0xc000106008)}
+StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.197023 -0700 PDT
+
+vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKeys:[{name:method}] Measure:0xc00000c030 Aggregation:0x118d8e0}
+[]*view.Row{(*view.Row)(0xc000108060)}
+	Row: 0: &view.Row{Tags:[]tag.Tag{tag.Tag{Key:tag.Key{name:"method"}, Value:"main"}}, Data:(*view.CountData)(0xc000106080)}
+StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.301678 -0700 PDT
+
+vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKeys:[{name:method}] Measure:0xc00000c030 Aggregation:0x118d8e0}
+[]*view.Row{(*view.Row)(0xc000118000)}
+	Row: 0: &view.Row{Tags:[]tag.Tag{tag.Tag{Key:tag.Key{name:"method"}, Value:"main"}}, Data:(*view.CountData)(0xc0000ca018)}
+StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.399842 -0700 PDT
+
+vd.View: &{Name:demo/loop_iterations Description:Number of loop iterations TagKeys:[{name:method}] Measure:0xc00000c030 Aggregation:0x118d8e0}
+[]*view.Row{(*view.Row)(0xc000118060)}
+	Row: 0: &view.Row{Tags:[]tag.Tag{tag.Tag{Key:tag.Key{name:"method"}, Value:"main"}}, Data:(*view.CountData)(0xc0000ca090)}
+StartTime: 2018-08-08 00:31:02.096592 -0700 PDT EndTime: 2018-08-08 00:31:02.498909 -0700 PDT
+```
+
+## Notes
+
+* Please remember to invoke [view.RegisterExporter](https://godoc.org/go.opencensus.io/stats/view#RegisterExporter) so that your exporter
+will receive exported view data.
+
+* To change the frequency at which your view data will be exported, please see [view.SetReportingPeriod](https://godoc.org/go.opencensus.io/stats/view#SetReportingPeriod)
+
+## References
+
+Name|Link
+---|---
+Metrics/Stats GoDoc for Measures|[https://godoc.org/go.opencensus.io/stats](https://godoc.org/go.opencensus.io/stats)
+Stats View GoDoc|[https://godoc.org/go.opencensus.io/stats/view](https://godoc.org/go.opencensus.io/stats/view)
+OpenCensus Go exporters|[Some OpenCensus Go exporters](/supported-exporters/go/)

--- a/content/exporters/custom-exporter/Go/Trace.md
+++ b/content/exporters/custom-exporter/Go/Trace.md
@@ -1,0 +1,154 @@
+---
+title: "Trace exporter"
+draft: false
+weight: 3
+aliases: [/custom_exporter/go/trace]
+---
+
+- [Introduction](#introduction)
+- [Implementation](#implementation)
+- [Runnable example](#runnable-example)
+- [Notes](#notes)
+- [References](#references)
+
+## Introduction
+A trace exporter must conform to the interface [trace.Exporter](https://godoc.org/go.opencensus.io/trace#Exporter)
+
+which for purposes of brevity is:
+
+```go
+import "go.opencensus.io/trace"
+
+type Exporter interface {
+    ExportSpan(s *trace.SpanData)
+}
+```
+
+whose sole method `ExportSpan` is the one in which you'll process and translate [Span Data](https://godoc.org/go.opencensus.io/trace#SpanData) into the data that your trace backend accepts.
+
+## Implementation
+
+For example, let's make a custom trace exporter that will print span data to standard output.
+
+```go
+import (
+	"log"
+
+	"go.opencensus.io/trace"
+)
+
+type customExporter struct{}
+
+// Compile time assertion that the exporter implements trace.Exporter
+var _ trace.Exporter = (*customExporter)(nil)
+
+func (cse *customExporter) ExportSpan(sd *trace.SpanData) {
+	log.Printf("Name: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\nStartTime: %s\nEndTime: %s\nAnnotations: %+v\n",
+		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID, sd.StartTime, sd.EndTime, sd.Annotations)
+}
+```
+
+and then afterwards we must ensure that we invoke `trace.RegisterExporter` with an instance of the exporter, like this:
+
+```go
+trace.RegisterExporter(new(customTraceExporter))
+```
+
+## Runnable example
+and now to test it out as we would in a typically linked program
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"go.opencensus.io/trace"
+)
+
+type customTraceExporter struct{}
+
+func (ce *customTraceExporter) ExportSpan(sd *trace.SpanData) {
+	fmt.Printf("Name: %s\nTraceID: %x\nSpanID: %x\nParentSpanID: %x\nStartTime: %s\nEndTime: %s\nAnnotations: %+v\n\n",
+		sd.Name, sd.TraceID, sd.SpanID, sd.ParentSpanID, sd.StartTime, sd.EndTime, sd.Annotations)
+}
+
+func main() {
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	// Please remember to register your exporter
+	// so that it can receive exported spanData.
+	trace.RegisterExporter(new(customTraceExporter))
+
+	for i := 0; i < 5; i++ {
+		_, span := trace.StartSpan(context.Background(), fmt.Sprintf("sample-%d", i))
+		span.Annotate([]trace.Attribute{trace.Int64Attribute("invocations", 1)}, "Invoked it")
+		span.End()
+                <-time.After(10 * time.Millisecond)
+	}
+	<-time.After(500 * time.Millisecond)
+}
+```
+
+will print out something like this
+
+```shell
+$ go run trace.go
+Name: sample-0
+TraceID: 3635343562376561613230663237336363393634666366376234643430663662
+SpanID: 64653466326237353234396336636564
+ParentSpanID: 30303030303030303030303030303030
+StartTime: 2018-08-07 23:56:28.988467 -0700 PDT m=+0.000804818
+EndTime: 2018-08-07 23:56:28.988476405 -0700 PDT m=+0.000814223
+Annotations: [{Time:2018-08-07 23:56:28.988472 -0700 PDT m=+0.000809888 Message:Invoked it Attributes:map[invocations:1]}]
+
+Name: sample-1
+TraceID: 3631356237303164353934366438313833613738396531646234393631613864
+SpanID: 63666339366562323265316464633435
+ParentSpanID: 30303030303030303030303030303030
+StartTime: 2018-08-07 23:56:28.999329 -0700 PDT m=+0.011666890
+EndTime: 2018-08-07 23:56:28.999364111 -0700 PDT m=+0.011702001
+Annotations: [{Time:2018-08-07 23:56:28.999345 -0700 PDT m=+0.011682925 Message:Invoked it Attributes:map[invocations:1]}]
+
+Name: sample-2
+TraceID: 3932373762333630316665363537636262383734366239616466333134333761
+SpanID: 63303433623265663338396534623965
+ParentSpanID: 30303030303030303030303030303030
+StartTime: 2018-08-07 23:56:29.010102 -0700 PDT m=+0.022440081
+EndTime: 2018-08-07 23:56:29.010108997 -0700 PDT m=+0.022447078
+Annotations: [{Time:2018-08-07 23:56:29.010104 -0700 PDT m=+0.022442411 Message:Invoked it Attributes:map[invocations:1]}]
+
+Name: sample-3
+TraceID: 3837656536656334653364353364353631643866386366623739396230386263
+SpanID: 62316264663532633433316662626636
+ParentSpanID: 30303030303030303030303030303030
+StartTime: 2018-08-07 23:56:29.022949 -0700 PDT m=+0.035286932
+EndTime: 2018-08-07 23:56:29.022955736 -0700 PDT m=+0.035293668
+Annotations: [{Time:2018-08-07 23:56:29.022951 -0700 PDT m=+0.035289112 Message:Invoked it Attributes:map[invocations:1]}]
+
+Name: sample-4
+TraceID: 3939356334633639616539393962386366643234363936613531643931383962
+SpanID: 61323337333936613464613032613466
+ParentSpanID: 30303030303030303030303030303030
+StartTime: 2018-08-07 23:56:29.03581 -0700 PDT m=+0.048148078
+EndTime: 2018-08-07 23:56:29.035817031 -0700 PDT m=+0.048155109
+Annotations: [{Time:2018-08-07 23:56:29.035812 -0700 PDT m=+0.048150248 Message:Invoked it Attributes:map[invocations:1]}]
+```
+
+## Notes
+
+* Please remember to invoke [trace.RegisterExporter](https://godoc.org/go.opencensus.io/trace#RegisterExporter) so that your exporter
+will receive exported spans.
+
+* Your exporter will be invoked after a span's [End](https://godoc.org/go.opencensus.io/trace#Span.End) method has been invoked
+* If you need to do heavy processing in the `ExportSpan` method, please do it in a goroutine because ExportSpan is invoked
+on the fast path
+
+## References
+
+Name|Link
+---|---
+Trace GoDoc|[https://godoc.org/go.opencensus.io/trace](https://godoc.org/go.opencensus.io/trace)
+OpenCensus Go exporters|[Some OpenCensus Go exporters](/supported-exporters/go/)

--- a/content/exporters/custom-exporter/Go/_index.md
+++ b/content/exporters/custom-exporter/Go/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Go"
+draft: false
+weight: 3
+class: "resized-logo"
+logo: /images/gopher.png
+---
+
+#### Introduction
+As already introduced in section [Core Concepts/Exporters](/core-concepts/exporters/), exporters
+are the vendor agnostic mechanism that OpenCensus provides to allow you to process span data and metrics
+before sending them to any of your trace or metrics backends.
+
+You'll learn how to create the following exporters:
+
+{{% children %}}

--- a/content/exporters/custom-exporter/Java/Trace.md
+++ b/content/exporters/custom-exporter/Java/Trace.md
@@ -1,0 +1,281 @@
+---
+title: "Trace exporter"
+draft: false
+weight: 3
+aliases: [/custom_exporter/java/trace]
+---
+
+- [Introduction](#introduction)
+- [Implementation](#implementation)
+- [Runnable example](#runnable-example)
+- [Notes](#notes)
+- [References](#references)
+
+## Introduction
+
+A trace exporter must extend the abstract class [SpanExporter.Handler](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanExporter.Handler.html) implementing the `export` method
+
+which for purposes of brevity is:
+
+```java
+import java.util.Collection;
+
+import io.opencensus.trace.export.SpanData;
+
+public void export(Collection<SpanData> spanDataList);
+```
+
+The sole method `export` will be used to process and translate a collection of [SpanData](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanData.html) to your desired trace backend's data.
+
+After an exporter is created, it must be registered with [SpanExporter.registerHandler](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanExporter.html#registerHandler-java.lang.String-io.opencensus.trace.export.SpanExporter.Handler-)
+
+```java
+SpanExporter.registerHandler(nameOfTheExporter, anInstanceOfTheExporter);
+```
+
+## Implementation
+
+For example, let's make a custom trace exporter that will print span data to standard output.
+
+Inside file `src/main/java/oc/tutorials/CustomTraceExporter.java` we'll write the following code
+
+```java
+package oc.tutorials;
+
+import java.util.Collection;
+
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.SpanData;
+import io.opencensus.trace.export.SpanExporter;
+
+public class CustomTraceExporter extends SpanExporter.Handler {
+    @Override
+    public void export(Collection<SpanData> spanDataList) {
+        for (SpanData sd : spanDataList) {
+            SpanContext sc = sd.getContext();
+            System.out.println(String.format(
+                "Name: %s\nTraceID: %s\nSpanID: %s\nParentSpanID: %s\nStartTime: %d\nEndTime: %d\nAnnotations: %s\n\n",
+                    sd.getName(), sc.getTraceId(), sc.getSpanId(), sd.getParentSpanId(),
+                    sd.getStartTimestamp().getSeconds(), sd.getEndTimestamp().getSeconds(), sd.getAnnotations()));
+        }
+    }
+
+    public static void createAndRegister() {
+        // Please remember to register your exporter
+        // so that it can receive exportered spanData.
+        Tracing.getExportComponent().getSpanExporter().registerHandler(CustomTraceExporter.class.getName(), new CustomTraceExporter());
+    }
+}
+```
+
+## Runnable example
+
+With the previous implementation, here is a fully runnable example, that we'll run using Maven.
+
+{{<tabs Java_Code pom_xml>}}
+{{<highlight java>}}
+package oc.tutorials;
+
+import java.util.Collection;
+
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.export.SpanData;
+import io.opencensus.trace.export.SpanExporter;
+import io.opencensus.trace.samplers.Samplers;
+
+public class CustomTraceExporter extends SpanExporter.Handler {
+    private static Tracer tracer = Tracing.getTracer();
+
+    public static void main(String ...args) {
+        // Firstly create and register the exporter
+        CustomTraceExporter.createAndRegister();
+
+        // For demo purposes, we'll always sample
+        TraceConfig traceConfig = Tracing.getTraceConfig();
+        traceConfig.updateActiveTraceParams(
+                traceConfig.getActiveTraceParams().toBuilder().setSampler(Samplers.alwaysSample()).build());
+
+        // Do some work
+        for (int i = 0; i < 5; i++) {
+            String name = String.format("sample-%d", i);
+            Scope ss = tracer.spanBuilder(name).startScopedSpan();
+            tracer.getCurrentSpan().addAnnotation("This annotation is for " + name);
+            sleep(200); // Sleep for 200 milliseconds
+            ss.close();
+        }
+
+        sleep(8000); // Sleep for 8 seconds to give exporting time to complete
+        System.exit(0);
+    }
+
+    @Override
+    public void export(Collection<SpanData> spanDataList) {
+        for (SpanData sd : spanDataList) {
+            SpanContext sc = sd.getContext();
+            System.out.println(String.format(
+                "Name: %s\nTraceID: %s\nSpanID: %s\nParentSpanID: %s\nStartTime: %d\nEndTime: %d\nAnnotations: %s\n\n",
+                    sd.getName(), sc.getTraceId(), sc.getSpanId(), sd.getParentSpanId(),
+                    sd.getStartTimestamp().getSeconds(), sd.getEndTimestamp().getSeconds(), sd.getAnnotations()));
+        }
+    }
+
+    public static void createAndRegister() {
+        // Please remember to register your exporter
+        // so that it can receive exportered spanData.
+        Tracing.getExportComponent().getSpanExporter().registerHandler(CustomTraceExporter.class.getName(), new CustomTraceExporter());
+    }
+
+    private static void sleep(int ms) {
+        // A helper to avoid try-catch when invoking Thread.sleep so that
+        // sleeps can be succinct and not permeated by exception handling.
+        try {
+            Thread.sleep(ms);
+        } catch(Exception e) {
+            System.err.println(String.format("Failed to sleep for %dms. Exception: %s", ms, e));
+        }
+    }
+}
+{{</highlight>}}
+
+{{<highlight xml>}}
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>oc.tutorial</groupId>
+    <artifactId>tracetutorial</artifactId>
+    <packaging>jar</packaging>
+    <version>1.0-SNAPSHOT</version>
+    <name>quickstart</name>
+    <url>http://maven.apache.org</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-api</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-impl</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.7.0</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                    </configuration>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>appassembler-maven-plugin</artifactId>
+                    <version>1.10</version>
+                    <configuration>
+                        <programs>
+                            <program>
+                                <id>CustomTraceExporter</id>
+                                <mainClass>oc.tutorials.CustomTraceExporter</mainClass>
+                            </program>
+                        </programs>
+                    </configuration>
+                </plugin>
+            </plugins>
+
+        </pluginManagement>
+
+    </build>
+</project>
+{{</highlight>}}
+{{</tabs>}}
+
+will print out something like this
+```shell
+$ mvn exec:java -Dexec.mainClass=oc.tutorials.CustomTraceExporter
+Name: sample-0
+TraceID: TraceId{traceId=1cdffe16132f7682f94b1777da7b41c7}
+SpanID: SpanId{spanId=e7c7c30546527d21}
+ParentSpanID: null
+StartTime: 1533768923
+EndTime: 1533768923
+Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=1533768923, nanos=227544959}, event=Annotation{description=This annotation is for sample-0, attributes={}}}], droppedEventsCount=0}
+
+
+Name: sample-1
+TraceID: TraceId{traceId=3c4af55e485cd5b6bc8b2c45042f0458}
+SpanID: SpanId{spanId=1e9a9ebe862f1a05}
+ParentSpanID: null
+StartTime: 1533768923
+EndTime: 1533768923
+Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=1533768923, nanos=431021767}, event=Annotation{description=This annotation is for sample-1, attributes={}}}], droppedEventsCount=0}
+
+
+Name: sample-2
+TraceID: TraceId{traceId=e20a916fed0ce71e9645f2ee1dde6cfd}
+SpanID: SpanId{spanId=2ce49605d29994c1}
+ParentSpanID: null
+StartTime: 1533768923
+EndTime: 1533768923
+Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=1533768923, nanos=633038726}, event=Annotation{description=This annotation is for sample-2, attributes={}}}], droppedEventsCount=0}
+
+
+Name: sample-3
+TraceID: TraceId{traceId=1dbb12d52d7d03a75c5a28612bd46b30}
+SpanID: SpanId{spanId=dfad460a90b67623}
+ParentSpanID: null
+StartTime: 1533768923
+EndTime: 1533768924
+Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=1533768923, nanos=833034459}, event=Annotation{description=This annotation is for sample-3, attributes={}}}], droppedEventsCount=0}
+
+
+Name: sample-4
+TraceID: TraceId{traceId=4991fe623a155ef9913bd5e9dc8f1ee8}
+SpanID: SpanId{spanId=a2d301f9e8f0cbc8}
+ParentSpanID: null
+StartTime: 1533768924
+EndTime: 1533768924
+Annotations: TimedEvents{events=[TimedEvent{timestamp=Timestamp{seconds=1533768924, nanos=34021598}, event=Annotation{description=This annotation is for sample-4, attributes={}}}], droppedEventsCount=0}
+
+
+```
+
+## Notes
+
+* Please remember to invoke [SpanExporter.registerHandler](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/export/SpanExporter.html#registerHandler-java.lang.String-io.opencensus.trace.export.SpanExporter.Handler-) for your created Trace exporter lest it won't receive exported span data
+
+* Your exporter's `export` method will receive exported span data only for spans that have been ended
+
+## References
+
+Name|Link
+---|---
+Trace JavaDoc |[io.opencensus.trace.*](https://static.javadoc.io/io.opencensus/opencensus-api/0.15.0/io/opencensus/trace/package-summary.html)
+OpenCensus JavaDoc|[io.opencensus.*](https://www.javadoc.io/doc/io.opencensus/opencensus-api/)
+OpenCensus Java exporters|[Some OpenCensus Java exporters](/supported-exporters/java/)

--- a/content/exporters/custom-exporter/Java/_index.md
+++ b/content/exporters/custom-exporter/Java/_index.md
@@ -1,0 +1,17 @@
+---
+title: "Java"
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/custom_exporter/java]
+logo: /images/java.png
+---
+
+#### Introduction
+As already introduced in section [Core Concepts/Exporters](/core-concepts/exporters/), exporters
+are the vendor agnostic mechanism that OpenCensus provides to allow you to process span data and metrics
+before sending them to any of your trace or metrics backends.
+
+You'll learn how to create the following exporters:
+
+{{% children %}}

--- a/content/exporters/custom-exporter/Node.js/Metrics.md
+++ b/content/exporters/custom-exporter/Node.js/Metrics.md
@@ -1,0 +1,96 @@
+---
+title: "Stats exporter"
+draft: false
+weight: 3
+---
+
+### Table of contents
+- [Introduction](#introduction)
+- [Implementation](#implementation)
+- [Runnable example](#runnable-example)
+- [Notes](#notes)
+- [References](#references)
+
+#### Introduction
+A stats exporter must implement [Stats Event Listener](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/exporters/types.ts#L34). Which must contain two methods, `onRegisterView` and `onRecord`, that is called whenever a new view is registered and whenever a new measurement is registered, respectively.
+
+Implemented in [Typescript](https://www.typescriptlang.org/), a stats exporter implementation should look something like this:
+
+Placed inside a file statsExporter.ts
+
+```typescript
+/** Defines a trace exporter interface. */
+class MyExporter implements StatsEventListener {
+  /**
+   * Is called whenever a new view is registered
+   * @param view The registered view
+   */
+  onRegisterView(view: View): void {
+    // Your on record code
+  };
+
+  /**
+   * Is called whenever a new measurement is recorded.
+   * @param views The views related to the measurement
+   * @param measurement The recorded measurement
+   */
+  onRecord(views: View[], measurement: Measurement): void {
+    // Your on record code
+  };
+}
+```
+
+#### Implementation
+
+For example, let's make a custom span exporter that will print span data to standard output.
+
+```typescript
+/** Exporter that receives stats data and shows in the log console. */
+export class MyConsoleStatsExporter implements StatsEventListener {
+  /**
+   * Called whenever a new view is registered
+   * @param view The registered view
+   */
+  onRegisterView(view: View) {
+    console.log(`View registered: ${view.name}, Measure registered: ${
+        view.measure.name}`);
+  }
+
+  /**
+   * Called whenever a measurement is recorded
+   * @param views The updated views
+   * @param measurement The recorded measurement
+   */
+  onRecord(views: View[], measurement: Measurement) {
+    console.log(`Measurement recorded: ${measurement.measure.name}`);
+  }
+}
+```
+
+#### Runnable example
+
+And now to test it out as we would in a typically linked program, let's create a `expample.js` file:
+
+{{<highlight javascript>}}
+var opencensus = require('@opencensus/core');
+var stats = new opencensus.Stats();
+
+// Let's create an instance of our just created exporter
+var exporter = new MyConsoleStatsExporter();
+// And register it
+stats.registerExporter(exporter);
+
+// Let's create a measure
+var measure = stats.createMeasureInt64('my/measure', "1");
+// our tags
+var tags = {myTagKey: 'myTagValue'};
+// a view
+var view = stats.createView('my/view', measure, 2, ['myTagKey'], 'my view');
+// and our measurement
+var measurement = {measure, tags, value: 10};
+
+// finaly, let's record it
+stats.record(measurement);
+{{</highlight>}}
+
+Now, run it with `node example.js` and you should see logs for our view beeing created and our measurement beeing recorded.

--- a/content/exporters/custom-exporter/Node.js/Trace.md
+++ b/content/exporters/custom-exporter/Node.js/Trace.md
@@ -1,0 +1,134 @@
+---
+title: "Trace exporter"
+draft: false
+weight: 3
+---
+
+### Table of contents
+- [Introduction](#introduction)
+- [Implementation](#implementation)
+- [Runnable example](#runnable-example)
+- [Notes](#notes)
+- [References](#references)
+
+#### Introduction
+A trace exporter must implement [Exporter](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/exporters/types.ts). Which must contain a method `onEndSpan`, that is called whenever a new span is ended. Usualy, this method writes the span to an [Exporter Buffer](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/exporters/exporter-buffer.ts#L26), allowing the Exporter to store spans and send batched data to a client. A trace exporter must also contain a `publish` method that will translate and export [root spans](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/trace/model/types.ts#L206) and its [child spans](https://github.com/census-instrumentation/opencensus-node/blob/master/packages/opencensus-core/src/trace/model/types.ts#L94) to the service, if an Exporter Buffer is used, it will be responsible for calling the `publish` method when it has reached its time or size capacity.
+
+A trace exporter should also have a `onStartSpan` method, that will be called whenever a span is started. This method is useful for close to real time exporters, like zPages.
+
+A trace exporter implementation should look something like this:
+
+```typescript
+/** Defines a trace exporter interface. */
+class MyExporter implements Exporter {
+  /**
+   * Sends a list of root spans to the service.
+   * @param rootSpans A list of root spans to publish.
+   */
+  publish(rootSpans: modelTypes.RootSpan[]): Promise<number|string|void> {
+	// Your publishing code
+  };
+
+  /**
+   * Event called whenever a span is started.
+   * @param span The started span
+   */
+  onStartSpan(span: RootSpan): void {
+	// Your on start span code
+  };
+  
+  /**
+   * Event called whenever a span is ended.
+   * @param span The ended span
+   */
+  onEndSpan(span: RootSpan): void {
+	// Your on end span code
+  };
+}
+```
+
+#### Implementation
+
+For example, let's make a custom trace exporter that will print span data to standard output.
+
+```typescript
+/** Format and sends span data to the console. */
+export class MyConsoleTraceExporter implements types.Exporter {
+  /** Buffer object to store the spans. */
+  private buffer: ExporterBuffer;
+
+  /**
+   * Constructs a new ConsoleLogExporter instance.
+   * @param config Exporter configuration object to create a console log
+   * exporter.
+   */
+  constructor(config: types.ExporterConfig) {
+    this.buffer = new ExporterBuffer(this, config);
+  }
+
+  /** 
+   * Our onStartSpan will do nothing. The exporting logic will be concentraded
+   * at the onEndSpan event.
+   */
+  onStartSpan(root: modelTypes.RootSpan) {}
+
+  /**
+   * Called whenever a span is ended.
+   * @param root Ended span.
+   */
+  onEndSpan(root: modelTypes.RootSpan) {
+	// We will just add the ended span to the buffer and wait for it to call
+	// the exporter back giving all the stored spans. This allow us to print
+	// spans in batch.
+    this.buffer.addToBuffer(root);
+  }
+  /**
+   * Sends the spans information to the console.
+   * @param rootSpans The stored spans
+   */
+  publish(rootSpans: modelTypes.RootSpan[]) {
+	// Let's iterate over all root spans formating the data the way we want
+    rootSpans.map((root) => {
+      const ROOT_STR = `RootSpan: {traceId: ${root.traceId}, spanId: ${
+          root.id}, name: ${root.name} }`;
+
+      const SPANS_STR: string[] = root.spans.map(
+          (span) => [`\t\t{spanId: ${span.id}, name: ${span.name}}`].join(
+              '\n'));
+
+      const result: string[] = [];
+      result.push(
+          ROOT_STR + '\n\tChildSpans:\n' +
+          `${SPANS_STR.join('\n')}`);
+      console.log(`${result}`);
+    });
+
+    return Promise.resolve();
+  }
+}
+```
+
+#### Runnable example
+
+And now to test it out as we would in a typically linked program, let's create a `expample.js` file:
+
+```javascript
+var tracing = require('@opencensus/opencensus-nodejs');
+
+// Let's create an instance of our just created exporter
+var exporter = new MyConsoleTraceExporter();
+// And start tracing with it
+tracing.registerExporter(exporter).start();
+
+// Now, lets create a simple HTTP 2 server
+var http2 = require('http2')
+var server2 = http2.createServer();
+
+// On every call to http://localhost:8080 we will return a Hello World message
+server2.on('stream', (stream, requestHeaders) => {
+    stream.end("Hello World");
+});
+server2.listen(8080);
+```
+
+Now, run it with `node example.js` and go to [http://localhost:8080](http://localhost:8080) on your browser. In the begining, you may see nothing in the console, but a few seconds latter, the exporter buffer kicks in and calls the publish method on your console log exporter, this will print the span info we wanted.

--- a/content/exporters/custom-exporter/Node.js/_index.md
+++ b/content/exporters/custom-exporter/Node.js/_index.md
@@ -1,0 +1,16 @@
+---
+title: "Node.js"
+draft: false
+weight: 3
+class: "resized-logo"
+logo: /images/nodejs.png
+---
+
+#### Introduction
+As already introduced in section [Core Concepts/Exporters](/core-concepts/exporters/), exporters
+are the vendor agnostic mechanism that OpenCensus provides to allow you to process span data and metrics
+before sending them to any of your trace or metrics backends.
+
+You'll learn how to create the following exporters:
+
+{{% children %}}

--- a/content/exporters/custom-exporter/_index.md
+++ b/content/exporters/custom-exporter/_index.md
@@ -1,0 +1,24 @@
+---
+title: "Writing a custom exporter"
+draft: false
+weight: 56
+class: "resized-logo"
+aliases: [/custom_exporter]
+logo: /images/opencensus-logo.png
+---
+
+As already introduced, OpenCensus is a vendor-agnostic library that allows you collect traces and metrics, allowing you
+to export that data to backends of your choice, in your applications.
+
+The OpenCensus community has and continues to implement [various exporters](/guides/exporters/supported-exporters/).
+
+However, this guide is to enable anyone and any vendor to implement their custom exporter as per languages:
+
+<abbr class="trace-exporter blue white-text">T</abbr> Tracing guide available
+
+<abbr class="stats-exporter teal white-text">S</abbr> Stats guide available
+
+{{<card-exporter target-url="cpp" src="/images/cpp.png" lang="C++" tracing="true" stats="true">}}
+{{<card-exporter target-url="go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
+{{<card-exporter target-url="java" src="/images/java-icon.png" lang="Java" tracing="true">}}
+{{<card-exporter target-url="node.js" src="/images/nodejs.png" lang="Node.js" tracing="true" stats="true">}}

--- a/content/exporters/supported-exporters/Go/ApplicationInsights.md
+++ b/content/exporters/supported-exporters/Go/ApplicationInsights.md
@@ -1,0 +1,92 @@
+---
+title: "Azure Monitor"
+date: 2018-10-22
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/applicationinsights]
+logo: /img/partners/microsoft_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Azure Monitor is an extensible Application Performance Management (APM) service for web developers on multiple platforms. Offered by Microsoft Azure, it's a complete at-scale telemetry and monitoring solution.
+
+If you don't have an Azure account yet, [click here](https://docs.microsoft.com/azure/application-insights/app-insights-overview) to start.
+
+## Creating the exporter
+Azure Monitor does not need a dedicated exporter to work with OpenCensus. Instead, it uses the readily available default exporter along with a dedicated agent known as Local Forwarder. 
+
+To learn about Local Forwarder and how to set it up, visit [this link](https://docs.microsoft.com/azure/application-insights/opencensus-local-forwarder).
+
+Here's an example of setting things up on the OpenCensus side (see [Local Forwarder repo](https://github.com/Microsoft/ApplicationInsights-LocalForwarder/blob/master/examples/opencensus/go-app/main.go) for the most up-to-date example):
+
+{{<highlight go>}}
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"io/ioutil"
+
+	ocagent "contrib.go.opencensus.io/exporter/ocagent"
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	// Register trace exporters to export the collected data.
+	serviceName := os.Getenv("SERVICE_NAME")
+	if len(serviceName) == 0 {
+		serviceName = "go-app"
+	}
+	agentEndpoint := os.Getenv("OCAGENT_TRACE_EXPORTER_ENDPOINT")
+	if len(agentEndpoint) == 0 {
+		agentEndpoint = fmt.Sprintf("%s:%d", ocagent.DefaultAgentHost, ocagent.DefaultAgentPort)
+	}
+
+	exporter, err := ocagent.NewExporter(ocagent.WithInsecure(), ocagent.WithServiceName(serviceName), ocagent.WithAddress(agentEndpoint))
+	if err != nil {
+		log.Fatalf("Failed to create the agent exporter: %v", err)
+	}
+
+	trace.RegisterExporter(exporter)
+
+	// Since we're sending data to Local Forwarder, we will always sample in order for Live Metrics Stream to work properly
+	// If your application is sending high volumes of data and you're not using Live Metrics Stream, provide more conservative value here
+	// Local Forwarder https://docs.microsoft.com/azure/application-insights/opencensus-local-forwarder
+	// Live Metrics Stream https://docs.microsoft.com/azure/application-insights/app-insights-live-stream
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	client := &http.Client{Transport: &ochttp.Transport{Propagation: &tracecontext.HTTPFormat{}}}
+
+	http.HandleFunc("/call", func(w http.ResponseWriter, req *http.Request) {
+		newReq, _ := http.NewRequest("GET", "http://blank.org", nil)
+
+		// Propagate the trace header info in the outgoing requests.
+		newReq = newReq.WithContext(req.Context())
+		msg := "Hello world from " + serviceName
+		resp, err := client.Do(newReq)
+		if err == nil {
+			blob, _ := ioutil.ReadAll(resp.Body)
+			resp.Body.Close()
+                      msg = fmt.Sprintf("%s\n%s", msg, blob)
+		} else {
+			msg = fmt.Sprintf("%s Error: %v", msg, err)
+		}
+
+		fmt.Fprintf(w, msg)
+	})
+	log.Fatal(http.ListenAndServe(":50030", &ochttp.Handler{Propagation: &tracecontext.HTTPFormat{}}))
+}
+{{</highlight>}}
+
+
+## Viewing your traces
+You must have an Azure account to view your data. If you don't have one yet, [click here](https://docs.microsoft.com/azure/application-insights/app-insights-overview) to start.

--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -1,0 +1,118 @@
+---
+title: "Datadog (Stats and Tracing)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/datadog]
+logo: /img/partners/datadog_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+[Datadog](https://www.datadoghq.com/) is a real-time monitoring system that supports distributed tracing and monitoring.
+
+Its OpenCensus Go exporter is available at [https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog](https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog)
+
+
+## Creating the exporter
+
+To create the exporter, we'll need:
+* Datadog credentials which you can get from [Here](https://docs.datadoghq.com/getting_started/)
+* Create an exporter in code
+
+This is possible by importing the exporter
+
+{{<highlight go>}}
+import "github.com/Datadog/opencensus-go-exporter-datadog"
+
+// then create the actual exporter
+dd := datadog.NewExporter(datadog.Options{})
+{{</highlight>}}
+
+and then to add stats, tracing and then collectively
+
+{{<tabs Stats Tracing All>}}
+{{<highlight go>}}
+package main
+
+import (
+  "log"
+
+  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "go.opencensus.io/stats/view"
+)
+
+func main() {
+  dd, err := datadog.NewExporter(datadog.Options{})
+  if err != nil {
+    log.Fatalf("Failed to create the Datadog exporter: %v", err)
+  }
+  // It is imperative to invoke flush before your main function exits
+  defer dd.Stop()
+
+  // Register it as a metrics exporter
+  view.RegisterExporter(dd)
+}
+{{</highlight>}}
+
+{{<highlight go>}}
+package main
+
+import (
+   "log"
+
+  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "go.opencensus.io/trace"
+)
+
+func main() {
+  dd, err := datadog.NewExporter(datadog.Options{})
+  if err != nil {
+    log.Fatalf("Failed to create the Datadog exporter: %v", err)
+  }
+  // It is imperative to invoke flush before your main function exits
+  defer dd.Stop()
+
+  // Register it as a metrics exporter
+  trace.RegisterExporter(dd)
+}
+{{</highlight>}}
+
+{{<highlight go>}}
+package main
+
+import (
+  "log"
+
+  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "go.opencensus.io/stats/view"
+  "go.opencensus.io/trace"
+)
+
+func main() {
+  dd, err := datadog.NewExporter(datadog.Options{})
+  if err != nil {
+    log.Fatalf("Failed to create the Datadog exporter: %v", err)
+  }
+  // It is imperative to invoke flush before your main function exits
+  defer dd.Stop()
+
+  // Register it as a metrics exporter
+  view.RegisterExporter(sd)
+
+  // Register it as a metrics exporter
+  trace.RegisterExporter(dd)
+}
+{{</highlight>}}
+{{</tabs>}}
+
+## Viewing your metrics
+Please visit [https://docs.datadoghq.com/graphing/](https://docs.datadoghq.com/graphing/)
+
+## Viewing your traces
+Please visit [https://docs.datadoghq.com/tracing/](https://docs.datadoghq.com/tracing/)

--- a/content/exporters/supported-exporters/Go/Honeycomb.md
+++ b/content/exporters/supported-exporters/Go/Honeycomb.md
@@ -1,0 +1,63 @@
+---
+title: "Honeycomb.io (Tracing)"
+date: 2018-10-16
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/honeycomb]
+logo: /img/honeycomb-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+
+[Honeycomb](www.honeycomb.io) is a hosted service for debugging your software in production. Capture traces or individual events, then speedily slice and dice your data to uncover patterns, find outliers, and understand historical trends.
+
+Honeycomb Tracing offers an unparalleled ability to run high-level queries in order to identify which traces are worth investigating, before digging deep into the details of an individual exemplar trace. Easily go from insights on your application from a bird's eye view, to a classic waterfall view of a specific trace, and back. For a walkthrough of this flow in action, [visit our blog](https://www.honeycomb.io/blog/2018/07/there-and-back-again-a-honeycomb-tracing-story/).
+
+Its OpenCensus Go exporter is available at [https://github.com/honeycombio/opencensus-exporter](https://github.com/honeycombio/opencensus-exporter)
+
+## Creating the exporter
+
+To create the exporter, we'll need to:
+
+- Create an exporter in code
+- Pass in your Honeycomb API key, found on your Honeycomb Team Settings page. ([Sign up for free](https://ui.honeycomb.io/signup) if you haven’t already!)
+- Pass in your Honeycomb dataset name
+
+{{<highlight go>}}
+package main
+
+import (
+    honeycomb "github.com/honeycombio/opencensus-exporter/honeycomb"
+    "go.opencensus.io/trace"
+)
+
+func main() {
+    exporter := honeycomb.NewExporter("YOUR-HONEYCOMB-WRITE-KEY", "YOUR-DATASET-NAME")
+    defer exporter.Close()
+
+    sampleFraction := 0.5
+    trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(sampleFraction)})
+    // If you use the Open Census Probability Sampler, be sure to pass that sampleFraction to the exporter
+    // so that Honeycomb can pick it up and make sure we handle your sampling properly.
+    exporter.SampleFraction = sampleFraction
+
+    trace.RegisterExporter(exporter)
+    // ...
+}
+{{</highlight>}}
+
+## Viewing your traces
+
+Please visit [the Honeycomb UI](https://ui.honeycomb.io/) to view your traces.
+
+Learn more about exploring your trace data [here](https://docs.honeycomb.io/working-with-data/tracing/explore-trace-data/), or play around with some of our data [here](play.honeycomb.io/tracing).
+
+## Project link
+
+You can find out more about Honeycomb at [https://www.honeycomb.io/](https://www.honeycomb.io/)

--- a/content/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/exporters/supported-exporters/Go/Jaeger.md
@@ -1,0 +1,72 @@
+---
+title: "Jaeger (Tracing)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/jaeger]
+logo: /img/partners/jaeger_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
+It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+* Distributed context propagation
+* Distributed transaction monitoring
+* Root cause analysis
+* Service dependency analysis
+* Performance / latency optimization
+
+OpenCensus Go has support for this exporter available through package [go.opencensus.io/exporter/jaeger](https://godoc.org/go.opencensus.io/exporter/jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
+
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Jaeger endpoint available to receive traces
+
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+
+	"go.opencensus.io/exporter/jaeger"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	// Port details: https://www.jaegertracing.io/docs/getting-started/
+	agentEndpointURI := "localhost:6831"
+	collectorEndpointURI := "http://localhost:14268"
+
+	je, err := jaeger.NewExporter(jaeger.Options{
+		AgentEndpoint: agentEndpointURI,
+		Endpoint:      collectorEndpointURI,
+		ServiceName:   "demo",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create the Jaeger exporter: %v", err)
+	}
+
+	// And now finally register it as a Trace Exporter
+	trace.RegisterExporter(je)
+}
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Jaeger UI endpoint [http://localhost:16686](http://localhost:16686)
+
+## Project link
+You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/exporters/supported-exporters/Go/Prometheus.md
@@ -1,0 +1,105 @@
+---
+title: "Prometheus (Stats)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/prometheus]
+logo: /img/prometheus-logo.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Running Prometheus](#running-prometheus)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Project link](#project-link)
+
+## Introduction
+Prometheus is a monitoring system that collects metrics, by scraping
+exposed endpoints at regular intervals, evaluating rule expressions.
+It can also trigger alerts if certain conditions are met.
+
+OpenCensus Go allows exporting stats to Prometheus by means of the Prometheus package
+[go.opencensus.io/exporter/prometheus](https://godoc.org/go.opencensus.io/exporter/prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Import and use the Prometheus exporter package
+* Define a namespace that will uniquely identify our metrics when viewed on Prometheus
+* Expose a port on which we shall run a `/metrics` endpoint
+* With the defined port, we'll need a Promethus configuration file so that Prometheus can scrape from this endpoint
+{{<highlight go>}}
+import "go.opencensus.io/exporter/prometheus"
+
+// Then create the actual exporter
+pe, err := prometheus.NewExporter(prometheus.Options{
+    Namespace: "demo",
+})
+if err != nil {
+    log.Fatalf("Failed to create the Prometheus exporter: %v", err)
+}
+{{</highlight>}}
+
+An instance of the Prometheus exporter implements [http.Handler](https://golang.org/net/http#Handler)
+so we'll need to expose it on our port of choice say ":8888"
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+	"net/http"
+
+	"go.opencensus.io/exporter/prometheus"
+)
+
+func main() {
+	pe, err := prometheus.NewExporter(prometheus.Options{
+		Namespace: "demo",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create Prometheus exporter: %v", err)
+	}
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", pe)
+		if err := http.ListenAndServe(":8888", mux); err != nil {
+			log.Fatalf("Failed to run Prometheus /metrics endpoint: %v", err)
+		}
+	}()
+}
+{{</highlight>}}
+
+and then for our corresponding `prometheus.yaml` file:
+
+```shell
+global:
+  scrape_interval: 10s
+
+  external_labels:
+    monitor: 'demo'
+
+scrape_configs:
+  - job_name: 'demo'
+
+    scrape_interval: 10s
+
+    static_configs:
+      - targets: ['localhost:8888']
+```
+
+## Running Prometheus
+And then run Prometheus with your configuration
+```shell
+prometheus --config.file=prometheus.yaml
+```
+
+## Viewing your metrics
+Please visit [http://localhost:9090](http://localhost:9090)
+
+## Project link
+You can find out more about the Prometheus project at [https://prometheus.io/](https://prometheus.io/)

--- a/content/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/exporters/supported-exporters/Go/Stackdriver.md
@@ -1,0 +1,151 @@
+---
+title: "Stackdriver (Stats and Tracing)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/stackdriver]
+logo: /images/logo_gcp_vertical_rgb.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
+You can track how requests propagate through your application and receive detailed near real-time performance insights.
+Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
+and can capture traces from all of your VMs, containers, or Google App Engine projects.
+
+Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
+Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+
+Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more.
+
+OpenCensus Go has support for this exporter available through package [contrib.go.opencensus.io/exporter/stackdriver](https://godoc.org/contrib.go.opencensus.io/exporter/stackdriver)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Have a GCP Project ID
+* Create an exporter in code
+
+{{<highlight go>}}
+import "contrib.go.opencensus.io/exporter/stackdriver"
+
+// Then create the actual exporter
+sd, err := stackdriver.NewExporter(stackdriver.Options{
+    ProjectID: "demo-project-id",
+})
+if err != nil {
+    log.Fatalf("Failed to create the Stackdriver exporter: %v", err)
+}
+{{</highlight>}}
+
+{{% notice warning %}}
+Stackdriver's minimum stats reporting period must be >= 60 seconds. Find out why at this [official Stackdriver advisory](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
+{{% /notice %}}
+
+{{<tabs Stats Tracing All>}}
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/stats/view"
+)
+
+func main() {
+	sd, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: "demo-project-id",
+		// MetricPrefix helps uniquely identify your metrics.
+		MetricPrefix: "demo-prefix",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create the Stackdriver exporter: %v", err)
+	}
+	// It is imperative to invoke flush before your main function exits
+	defer sd.Flush()
+
+	// Register it as a metrics exporter
+	view.RegisterExporter(sd)
+	view.SetReportingPeriod(60 * time.Second)
+}
+{{</highlight>}}
+
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	sd, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: "demo-project-id",
+		// MetricPrefix helps uniquely identify your metrics.
+		MetricPrefix: "demo-prefix",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create the Stackdriver exporter: %v", err)
+	}
+	// It is imperative to invoke flush before your main function exits
+	defer sd.Flush()
+
+	// Register it as a trace exporter
+	trace.RegisterExporter(sd)
+}
+{{</highlight>}}
+
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+	"time"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	sd, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: "demo-project-id",
+		// MetricPrefix helps uniquely identify your metrics.
+		MetricPrefix: "demo-prefix",
+	})
+	if err != nil {
+		log.Fatalf("Failed to create the Stackdriver exporter: %v", err)
+	}
+	// It is imperative to invoke flush before your main function exits
+	defer sd.Flush()
+
+	// Register it as a metrics exporter
+	view.RegisterExporter(sd)
+	view.SetReportingPeriod(60 * time.Second)
+
+	// Register it as a trace exporter
+	trace.RegisterExporter(sd)
+}
+{{</highlight>}}
+{{</tabs>}}
+
+## Viewing your metrics
+Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
+
+## Viewing your traces
+Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/exporters/supported-exporters/Go/XRay.md
+++ b/content/exporters/supported-exporters/Go/XRay.md
@@ -1,0 +1,64 @@
+---
+title: "AWS X-Ray (Tracing)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/xray]
+logo: https://d1.awsstatic.com/product-marketing/X-Ray/x-ray_web-app_diagram_light.21c38e4500dca09b3c8ca4cf87f896f7bbfb8a3b.png
+---
+
+- [Introduction](#introduction)
+- [Requirements](#requirements)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+AWS X-Ray is a distributed trace collection and analysis system from Amazon Web Services.
+
+Its support is available by means of the X-Ray package [https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws](https://godoc.org/github.com/census-instrumentation/opencensus-go-exporter-aws)
+
+## Requirements
+You'll need to have an AWS Developer account, if you haven't yet, please visit
+In case you haven't yet enabled AWS X-Ray, please visit [https://console.aws.amazon.com/xray/home](https://console.aws.amazon.com/xray/home)
+
+## Creating the exporter
+
+This is possible by importing
+
+{{<highlight go>}}
+import xray "contrib.go.opencensus.io/exporter/aws"
+
+// Then create the actual exporter
+xe, err := xray.NewExporter(xray.WithVersion("latest"))
+if err != nil {
+        log.Fatalf("Failed to create the AWS X-Ray exporter: %v", err)
+}
+{{</highlight>}}
+
+Then finally register it as a trace exporter, to collectively give
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+
+	xray "contrib.go.opencensus.io/exporter/aws"
+	"go.opencensus.io/trace"
+)
+
+func main() {
+	xe, err := xray.NewExporter(xray.WithVersion("latest"))
+	if err != nil {
+		log.Fatalf("Failed to create the AWS X-Ray exporter: %v", err)
+	}
+	// It is imperative that your exporter invokes Flush before your program exits!
+	defer xe.Flush()
+
+	trace.RegisterExporter(xe)
+}
+{{</highlight>}}
+
+
+## Viewing your traces
+Please visit [https://console.aws.amazon.com/xray/home](https://console.aws.amazon.com/xray/home)

--- a/content/exporters/supported-exporters/Go/Zipkin.md
+++ b/content/exporters/supported-exporters/Go/Zipkin.md
@@ -1,0 +1,68 @@
+---
+title: "Zipkin (Tracing)"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/go/zipkin]
+logo: /img/zipkin-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
+
+It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
+
+OpenCensus Go has support for this exporter available through package [go.opencensus.io/exporter/zipkin](https://godoc.org/go.opencensus.io/exporter/zipkin)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Zipkin endpoint available to receive traces
+
+{{<highlight go>}}
+package main
+
+import (
+	"log"
+
+	"go.opencensus.io/exporter/zipkin"
+	"go.opencensus.io/trace"
+
+	openzipkin "github.com/openzipkin/zipkin-go"
+	zipkinHTTP "github.com/openzipkin/zipkin-go/reporter/http"
+)
+
+func main() {
+	localEndpointURI := "192.168.1.5:5454"
+	reporterURI := "http://localhost:9411/api/v2/spans"
+	serviceName := "server"
+
+	localEndpoint, err := openzipkin.NewEndpoint(serviceName, localEndpointURI)
+	if err != nil {
+		log.Fatalf("Failed to create Zipkin localEndpoint with URI %q error: %v", localEndpointURI, err)
+	}
+
+	reporter := zipkinHTTP.NewReporter(reporterURI)
+	ze := zipkin.NewExporter(reporter, localEndpoint)
+
+	// And now finally register it as a Trace Exporter
+	trace.RegisterExporter(ze)
+}
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
+
+## Project link
+You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/exporters/supported-exporters/Go/_index.md
+++ b/content/exporters/supported-exporters/Go/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Go"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 2
+class: "resized-logo"
+aliases: [/supported-exporters/go]
+logo: /images/gopher.png
+---
+
+OpenCensus Go provides support for various exporters like:
+
+{{% children %}}

--- a/content/exporters/supported-exporters/Java/Instana.md
+++ b/content/exporters/supported-exporters/Java/Instana.md
@@ -1,0 +1,71 @@
+---
+title: "Instana (Tracing)"
+date: 2018-07-21T18:52:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/instana]
+logo: /images/instana.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporters](#creating-the-exporters)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Instant provides AI Powered Application and Infrastructure Monitoring, allowing you to
+deliver Faster With Confidence, and automatic Analysis and Optimization.
+
+OpenCensus Java has support for this exporter available through package [io.opencensus.exporter.trace.instana](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-instana)
+
+More information can be found at the [Instana website](https://www.instana.com/)
+
+## Creating the trace exporter
+To create the trace exporter, you'll need to:
+
+* Have Instana credentials
+* Use Maven setup your pom.xml file
+* Create the exporter in code
+
+`pom.xml`
+```xml
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-api</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-impl</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-exporter-trace-instana</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+    </dependencies>
+```
+
+## Creating the exporter in code
+
+{{<highlight java>}}
+package io.opencensus.tutorial.instana;
+
+import io.opencensus.exporter.trace.instana.InstanaTraceExporter;
+
+public class InstanaTutorial {
+    public static void main(String ...args) {
+        String agentEndpointURI = "http://localhost:42699/com.instana.plugin.generic.trace";
+        InstanaTraceExporter.createAndRegister(agentEndpointURI);
+    }
+}
+{{</highlight>}}

--- a/content/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/exporters/supported-exporters/Java/Jaeger.md
@@ -1,0 +1,81 @@
+---
+title: "Jaeger (Tracing)"
+date: 2018-07-22T17:35:15-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/jaeger]
+logo: /img/partners/jaeger_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
+It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+* Distributed context propagation
+* Distributed transaction monitoring
+* Root cause analysis
+* Service dependency analysis
+* Performance / latency optimization
+
+OpenCensus Java has support for this exporter available through package [io.opencensus.exporter.trace.jaeger](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Jaeger endpoint available to receive traces
+
+If using Maven, add these to your `pom.xml` file
+```xml
+<properties>
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-trace-jaeger</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>${opencensus.version}</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
+
+{{<highlight java>}}
+package io.opencensus.tutorial.jaeger;
+
+import io.opencensus.exporter.trace.jaeger.JaegerTraceExporter;
+
+public class JaegerTutorial {
+    public static void main(String ...args) throws Exception {
+        JaegerTraceExporter.createAndRegister("http://127.0.0.1:14268/api/traces", "service-b");
+    }
+}
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Jaeger UI endpoint [http://localhost:16686](http://localhost:16686)
+
+## Project link
+You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/exporters/supported-exporters/Java/Prometheus.md
+++ b/content/exporters/supported-exporters/Java/Prometheus.md
@@ -1,0 +1,119 @@
+---
+title: "Prometheus (Stats)"
+date: 2018-07-22T14:27:35-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/java/prometheus]
+logo: /img/prometheus-logo.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Running Prometheus](#running-prometheus)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Project link](#project-link)
+
+## Introduction
+Prometheus is a monitoring system that collects metrics, by scraping
+exposed endpoints at regular intervals, evaluating rule expressions.
+It can also trigger alerts if certain conditions are met.
+
+OpenCensus Java allows exporting stats to Prometheus by means of the Prometheus package
+[io.opencensus.exporter.stats.prometheus](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Import and use the Prometheus exporter package
+* Define a namespace that will uniquely identify our metrics when viewed on Prometheus
+* Expose a port on which we shall run a `/metrics` endpoint
+* With the defined port, we'll need a Promethus configuration file so that Prometheus can scrape from this endpoint
+
+Add this to your `pom.xml` file:
+
+```xml
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-api</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-impl</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.opencensus</groupId>
+            <artifactId>opencensus-exporter-stats-prometheus</artifactId>
+            <version>${opencensus.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.3.0</version>
+        </dependency>
+    </dependencies>
+```
+
+We also need to expose the Prometheus endpoint say on address "localhost:8888".
+
+{{<highlight java>}}
+package io.opencensus.tutorial.prometheus;
+
+import io.opencensus.exporter.stats.prometheus.PrometheusStatsCollector;
+import io.prometheus.client.exporter.HTTPServer;
+
+public class PrometheusTutorial {
+    public static void main(String ...args) {
+        // Register the Prometheus exporter
+        PrometheusStatsCollector.createAndRegister();
+
+        // Run the server as a daemon on address "localhost:8888"
+        HTTPServer server = new HTTPServer("localhost", 8888, true);
+    }
+}
+{{</highlight>}}
+
+and then for our corresponding `prometheus.yaml` file:
+
+```shell
+global:
+  scrape_interval: 10s
+
+  external_labels:
+    monitor: 'demo'
+
+scrape_configs:
+  - job_name: 'demo'
+
+    scrape_interval: 10s
+
+    static_configs:
+      - targets: ['localhost:8888']
+```
+
+## Running Prometheus
+And then run Prometheus with your configuration
+```shell
+prometheus --config.file=prometheus.yaml
+```
+
+## Viewing your metrics
+Please visit [http://localhost:9090](http://localhost:9090)
+
+## Project link
+You can find out more about the Prometheus project at [https://prometheus.io/](https://prometheus.io/)

--- a/content/exporters/supported-exporters/Java/SignalFx.md
+++ b/content/exporters/supported-exporters/Java/SignalFx.md
@@ -1,0 +1,90 @@
+---
+title: "SignalFx (Stats)"
+date: 2018-07-22T16:58:03-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/java/signalfx]
+logo: /img/partners/signalFx_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [References](#references)
+
+## Introduction
+SignalFx is a real-time monitoring solution for cloud and distributed applications.
+SignalFx ingests that data and offers various visualizations on charts, dashboards and service maps,
+as well as real-time anomaly detection.
+
+OpenCensus Java has support for this exporter available through the package:
+
+* Stats [io.opencensus.exporter.stats.signalfx](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-signalfx)
+
+{{% notice tip %}}
+This guide makes use of SignalFx.
+You'll need to have:
+
+* A [SignalFx account](https://signalfx.com/)
+* The corresponding [data ingest token](https://docs.signalfx.com/en/latest/admin-guide/tokens.html)
+{{% /notice %}}
+
+## Creating the exporter
+
+
+Insert the following snippet in your `pom.xml`:
+
+```xml
+<properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-stats-signalfx</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>${opencensus.version}</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
+
+Instrument your application code with the following snippet:
+
+{{<highlight java>}}
+package io.opencensus.tutorial.signalfx;
+
+import io.opencensus.common.Duration;
+import io.opencensus.exporter.stats.signalfx.SignalFxStatsConfiguration;
+import io.opencensus.exporter.stats.signalfx.SignalFxStatsExporter;
+
+public class SignalFxTutorial {
+    public static void main(String ...args) {
+        String signalFxToken = "<this is my token>";
+
+        SignalFxStatsExporter.create(
+            SignalFxStatsConfiguration.builder()
+            .setToken(signalFxToken)
+            .setExportInterval(Duration.create(3, 2))
+            .build();
+        );
+    }
+}
+{{</highlight>}}
+
+## References
+
+Resource|URL
+---|---
+SignalFx stats exporter JavaDoc|https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-stats-signalfx

--- a/content/exporters/supported-exporters/Java/Zipkin.md
+++ b/content/exporters/supported-exporters/Java/Zipkin.md
@@ -1,0 +1,78 @@
+---
+title: "Zipkin (Tracing)"
+date: 2018-07-22T17:20:12-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/java/zipkin]
+logo: /img/zipkin-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
+
+It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
+
+OpenCensus Java has support for this exporter available through package [io.opencensus.exporter.trace.zipkin](https://www.javadoc.io/doc/io.opencensus/opencensus-exporter-trace-zipkin)
+
+{{% notice note %}}
+This guide makes use of Zipkin for visualizing your data. For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Zipkin endpoint available to receive traces
+
+If using Maven, add these to your `pom.xml` file
+```xml
+<properties>
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <opencensus.version>0.15.0</opencensus.version> <!-- The OpenCensus version to use -->
+</properties>
+
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-trace-zipkin</artifactId>
+    <version>${opencensus.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>${opencensus.version}</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
+
+Instrument your code with the following snippet:
+
+{{<highlight java>}}
+package io.opencensus.tutorial.zipkin;
+
+import io.opencensus.exporter.trace.zipkin.ZipkinTraceExporter;
+
+public class ZipkinTutorial {
+    public static void main(String ...args) throws Exception {
+        ZipkinTraceExporter.createAndRegister("http://localhost:9411/api/v2/spans", "service-a");
+    }
+}
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
+
+## Project link
+You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/exporters/supported-exporters/Java/_index.md
+++ b/content/exporters/supported-exporters/Java/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Java"
+date: 2018-07-21T18:40:01-02:00
+draft: false
+weight: 2
+class: "resized-logo"
+aliases: [/supported-exporters/java]
+logo: /images/java.png
+---
+
+For full reference, you can visit:
+
+* JavaDoc  [https://www.javadoc.io/doc/io.opencensus/opencensus-api](https://www.javadoc.io/doc/io.opencensus/opencensus-api)
+* Github repository [https://github.com/census-instrumentation/opencensus-java](https://github.com/census-instrumentation/opencensus-java)
+
+OpenCensus Java provides support for various exporters like:
+
+{{% children %}}

--- a/content/exporters/supported-exporters/Node.js/Instana.md
+++ b/content/exporters/supported-exporters/Node.js/Instana.md
@@ -1,0 +1,41 @@
+---
+title: "Instana (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /images/instana.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Instanta provides AI Powered Application and Infrastructure Monitoring, allowing you to
+deliver Faster With Confidence, and automatic Analysis and Optimization.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-instana](https://www.npmjs.com/package/@opencensus/exporter-instana)
+
+More information can be found at the [Instana website](https://www.instana.com/)
+
+## Installing the exporter
+You can install OpenCensus Instana Exporter by running these steps:
+
+```bash
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-instana
+```
+
+To use Instana as your exporter, first ensure that you have an [Instana agent running on your system](https://docs.instana.io/quick_start/getting_started/) and reporting to your environment. The Instana OpenCensus exporter directly communicates with the Instana agent in order to transmit data to Instana.
+
+## Creating the exporter
+Now let's use the Instana exporter:
+
+```js
+var tracing = require('@opencensus/nodejs');
+var instana = require('@opencensus/exporter-instana');
+
+var exporter = new instana.InstanaTraceExporter();
+
+tracing.registerExporter(exporter).start();
+```

--- a/content/exporters/supported-exporters/Node.js/Jaeger.md
+++ b/content/exporters/supported-exporters/Node.js/Jaeger.md
@@ -1,0 +1,59 @@
+---
+title: "Jaeger (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/partners/jaeger_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
+It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+* Distributed context propagation
+* Distributed transaction monitoring
+* Root cause analysis
+* Service dependency analysis
+* Performance / latency optimization
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-jaeger](https://www.npmjs.com/package/@opencensus/exporter-jaeger)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Jaeger Exporter by running these steps:
+
+```bash
+npm install @opencensus/core
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-jaeger
+```
+
+## Creating the exporter
+Now let's use the Jaeger exporter:
+
+```js
+var core = require('@opencensus/core');
+var tracing = require('@opencensus/nodejs');
+var jaeger = require('@opencensus/exporter-jaeger');
+
+var jaegerOptions = {
+  serviceName: 'opencensus-exporter-jaeger',
+  host: 'localhost',
+  port: 6832,
+  tags: [{key: 'opencensus-exporter-jeager', value: '0.0.1'}],
+  bufferTimeout: 10, // time in milliseconds
+  logger: core.logger.logger('debug'),
+  maxPacketSize: 1000
+};
+
+var exporter = new jaeger.JaegerTraceExporter(jaegerOptions);
+
+tracing.registerExporter(exporter).start();
+```

--- a/content/exporters/supported-exporters/Node.js/Prometheus.md
+++ b/content/exporters/supported-exporters/Node.js/Prometheus.md
@@ -1,0 +1,50 @@
+---
+title: "Prometheus (Stats)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/prometheus-logo.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Prometheus is a monitoring system that collects metrics, by scraping
+exposed endpoints at regular intervals, evaluating rule expressions.
+It can also trigger alerts if certain conditions are met.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-prometheus](https://www.npmjs.com/package/@opencensus/exporter-prometheus)
+
+{{% notice tip %}}
+For assistance setting up Prometheus, [Click here](/codelabs/prometheus) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Prometheus Exporter by running these steps:
+
+```bash
+npm install @opencensus/core
+npm install @opencensus/exporter-prometheus
+```
+
+## Creating the exporter
+Now let's use the Prometheus exporter:
+
+```js
+var {AggregationType, Measure, MeasureUnit, Stats} = require('@opencensus/core');
+var prometheus = require('@opencensus/exporter-prometheus');
+
+var stats = new Stats();
+
+var exporter = new prometheus.PrometheusTraceExporter({
+  port: 9464,
+  startServer: false
+});
+stats.registerExporter(exporter);
+
+exporter.startServer(function callback() {
+  // Callback
+});
+```

--- a/content/exporters/supported-exporters/Node.js/Zipkin.md
+++ b/content/exporters/supported-exporters/Node.js/Zipkin.md
@@ -1,0 +1,48 @@
+---
+title: "Zipkin (Tracing)"
+date: 2018-08-29T15:29:53-07:00
+draft: false
+class: "resized-logo"
+logo: /img/zipkin-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+
+## Introduction
+Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
+
+It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-zipkin](https://www.npmjs.com/package/@opencensus/exporter-zipkin)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+You can install OpenCensus Zipkin Exporter by running these steps:
+
+```bash
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-zipkin
+```
+
+## Creating the exporter
+Now let's use the Zipkin exporter:
+
+```js
+var tracing = require('@opencensus/nodejs');
+var zipkin = require('@opencensus/exporter-zipkin');
+
+// Add your zipkin url (ex http://localhost:9411/api/v2/spans)
+// and application name to the Zipkin options
+var options = {
+  url: 'your-zipkin-url',
+  serviceName: 'your-application-name'
+};
+
+var exporter = new zipkin.ZipkinTraceExporter(options);
+tracing.registerExporter(exporter).start();
+```

--- a/content/exporters/supported-exporters/Node.js/_index.md
+++ b/content/exporters/supported-exporters/Node.js/_index.md
@@ -1,0 +1,12 @@
+---
+title: "Node.js"
+date: 2018-08-15T14:26:12-07:00
+draft: false
+weight: 2
+class: "resized-logo"
+logo: /images/nodejs.png
+---
+
+OpenCensus Node.js provides support for various exporters like:
+
+{{% children %}}

--- a/content/exporters/supported-exporters/Node.js/stackdriver-stats.md
+++ b/content/exporters/supported-exporters/Node.js/stackdriver-stats.md
@@ -1,0 +1,71 @@
+---
+title: "Stackdriver (Stats)"
+date: 2018-07-22T23:47:14-07:00
+draft: false
+weight: 3
+logo: /images/logo_gcp_vertical_rgb.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporters](#creating-the-exporter)
+- [Viewing your metrics](#viewing-your-metrics)
+- [References](#references)
+
+
+## Introduction
+{{% notice note %}}
+This guide makes use of Stackdriver for visualizing your data. For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
+
+Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications. Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others. Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by integrating with Slack, PagerDuty, HipChat, Campfire, and more.
+
+OpenCensus Node has support for this exporter available through package:
+
+## Installing the exporter
+You can install OpenCensus Stackdriver Exporter by running these steps:
+
+{{<highlight bash>}}
+npm install @opencensus/core
+npm install @opencensus/exporter-stackdriver
+{{</highlight>}}
+
+## Creating the exporter
+To create the exporter, you'll need to:
+
+* Have a GCP Project ID
+* Have already enabled [Stackdriver Monitoring](https://cloud.google.com/monitoring/docs/quickstart), if not, please visit the [Code lab](/codelabs/stackdriver)
+* Enable your [Application Default Credentials](https://cloud.google.com/docs/authentication/getting-started) for authentication with:
+
+{{<highlight bash>}}
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
+{{</highlight>}}
+
+* Create the exporters in code
+
+{{% notice warning %}}
+Stackdriver's minimum stats reporting period must be >= 60 seconds. Find out why at this [official Stackdriver advisory](https://cloud.google.com/monitoring/custom-metrics/creating-metrics#writing-ts)
+{{% /notice %}}
+
+{{<highlight javascript>}}
+var opencensus = require('@opencensus/core');
+var stackdriver = require('@opencensus/exporter-stackdriver');
+
+// Add your project id to the Stackdriver options
+var exporter = new stackdriver.StackdriverStatsExporter({projectId: "your-project-id"});
+
+var stats = new opencensus.Stats();
+
+stats.registerExporter(exporter);
+{{</highlight>}}
+
+## Viewing your metrics
+Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
+
+## References
+
+Resource|URL
+---|---
+NPM: @opencensus/exporter-stackdriver|https://www.npmjs.com/package/@opencensus/exporter-stackdriver
+NPM: @opencensus/nodejs|https://www.npmjs.com/package/@opencensus/nodejs
+Github: OpenCensus for Node.js|https://github.com/census-instrumentation/opencensus-node/tree/master/packages/opencensus-nodejs

--- a/content/exporters/supported-exporters/Node.js/stackdriver-trace.md
+++ b/content/exporters/supported-exporters/Node.js/stackdriver-trace.md
@@ -1,0 +1,68 @@
+---
+title: "Stackdriver (Tracing)"
+date: 2018-07-22T23:47:14-07:00
+draft: false
+weight: 3
+logo: /images/logo_gcp_vertical_rgb.png
+---
+
+- [Introduction](#introduction)
+- [Installing the exporter](#installing-the-exporter)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [References](#references)
+
+## Introduction
+Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
+You can track how requests propagate through your application and receive detailed near real-time performance insights.
+Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations,
+and can capture traces from all of your VMs, containers, or Google App Engine projects.
+
+OpenCensus Node.js has support for this exporter available, distributed through NPM package [@opencensus/exporter-stackdriver](https://www.npmjs.com/package/@opencensus/exporter-stackdriver)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
+
+## Installing the exporter
+Install OpenCensus Stackdriver Exporter with:
+
+{{<highlight bash>}}
+npm install @opencensus/nodejs
+npm install @opencensus/exporter-stackdriver
+{{</highlight>}}
+
+## Creating the exporter
+To create the exporter, you'll need to:
+
+* Have a GCP Project ID
+* Have already enabled [Stackdriver Tracing](https://cloud.google.com/trace/docs/quickstart), if not, please visit the [Code lab](/codelabs/stackdriver)
+* Enable your [Application Default Credentials](https://cloud.google.com/docs/authentication/getting-started) for authentication with:
+
+{{<highlight bash>}}
+export GOOGLE_APPLICATION_CREDENTIALS=path/to/your/credential.json
+{{</highlight>}}
+
+To create the exporter, in code:
+
+{{<highlight javascript>}}
+var tracing = require('@opencensus/nodejs');
+var stackdriver = require('@opencensus/exporter-stackdriver');
+
+// Add your project id to the Stackdriver options
+var exporter = new stackdriver.StackdriverTraceExporter({projectId: "your-project-id"});
+
+tracing.registerExporter(exporter).start();
+{{</highlight>}}
+
+## Viewing your traces
+Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)
+
+## References
+
+Resource|URL
+---|---
+NPM: @opencensus/exporter-stackdriver|https://www.npmjs.com/package/@opencensus/exporter-stackdriver
+NPM: @opencensus/nodejs|https://www.npmjs.com/package/@opencensus/nodejs
+Github: OpenCensus for Node.js|https://github.com/census-instrumentation/opencensus-node/tree/master/packages/opencensus-nodejs

--- a/content/exporters/supported-exporters/Python/ApplicationInsights.md
+++ b/content/exporters/supported-exporters/Python/ApplicationInsights.md
@@ -1,0 +1,61 @@
+---
+title: "Azure Monitor"
+date: 2018-10-22
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/python/applicationinsights]
+logo: /img/partners/microsoft_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Azure Monitor is an extensible Application Performance Management (APM) service for web developers on multiple platforms. Offered by Microsoft Azure, it's a complete at-scale telemetry and monitoring solution.
+
+If you don't have an Azure account yet, [click here](https://docs.microsoft.com/azure/application-insights/app-insights-overview) to start.
+
+## Creating the exporter
+Azure Monitor does not need a dedicated exporter to work with OpenCensus. Instead, it uses the readily available default exporter along with a dedicated agent known as Local Forwarder. 
+
+To learn about Local Forwarder and how to set it up, visit [this link](https://docs.microsoft.com/azure/application-insights/opencensus-local-forwarder).
+
+Here's an example of setting things up on the OpenCensus side (see [Local Forwarder repo](https://github.com/Microsoft/ApplicationInsights-LocalForwarder/blob/master/examples/opencensus/python-app/app/views.py) for the most up-to-date example):
+
+{{<highlight python>}}
+from django.http import HttpResponse
+from django.shortcuts import render
+
+from opencensus.trace import config_integration
+from opencensus.trace.exporters.ocagent import trace_exporter
+from opencensus.trace import tracer as tracer_module
+from opencensus.trace.propagation.trace_context_http_header_format import TraceContextPropagator
+from opencensus.trace.exporters.transports.background_thread \
+    import BackgroundThreadTransport
+
+import time
+import os
+import requests
+
+INTEGRATIONS = ['httplib']
+
+service_name = os.getenv('SERVICE_NAME', 'python-service')
+config_integration.trace_integrations(INTEGRATIONS, tracer=tracer_module.Tracer(
+    exporter=trace_exporter.TraceExporter(
+        service_name=service_name,
+        endpoint=os.getenv('OCAGENT_TRACE_EXPORTER_ENDPOINT'),
+        transport=BackgroundThreadTransport),
+    propagator=TraceContextPropagator()))
+
+
+def call(request):
+    requests.get("http://go-app:50030/call")
+
+    return HttpResponse("hello world from " + service_name)
+{{</highlight>}}
+
+
+## Viewing your traces
+You must have an Azure account to view your data. If you don't have one yet, [click here](https://docs.microsoft.com/azure/application-insights/app-insights-overview) to start.

--- a/content/exporters/supported-exporters/Python/Jaeger.md
+++ b/content/exporters/supported-exporters/Python/Jaeger.md
@@ -1,0 +1,63 @@
+---
+title: "Jaeger (Tracing)"
+date: 2018-07-22T23:33:31-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/python/jaeger]
+logo: https://www.jaegertracing.io/img/jaeger-logo.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Jaeger, inspired by Dapper and OpenZipkin, is a distributed tracing system released as open source by Uber Technologies.
+It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+* Distributed context propagation
+* Distributed transaction monitoring
+* Root cause analysis
+* Service dependency analysis
+* Performance / latency optimization
+
+OpenCensus Python has support for this exporter available through package [opencensus.trace.exporters.jaeger_exporter](https://github.com/census-instrumentation/opencensus-python/blob/master/opencensus/trace/exporters/jaeger_exporter.py)
+
+{{% notice tip %}}
+For assistance setting up Jaeger, [Click here](/codelabs/jaeger) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Jaeger endpoint available to receive traces
+
+{{<highlight python>}}
+#!/usr/bin/env python
+
+from opencensus.trace.exporters.jaeger_exporter import JaegerExporter
+from opencensus.trace.tracer import Tracer
+
+def main():
+    je = JaegerExporter(service_name="service-b",
+                        host_name='localhost',
+                        agent_port=6831,
+                        endpoint='/api/traces')
+
+    tracer = Tracer(exporter=je)
+    with tracer.span(name='doingWork') as span:
+        for i in range(10):
+            continue
+
+if __name__ == "__main__":
+    main()
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Jaeger UI endpoint [http://localhost:16686](http://localhost:16686)
+
+## Project link
+You can find out more about the Jaeger project at [https://www.jaegertracing.io/](https://www.jaegertracing.io/)

--- a/content/exporters/supported-exporters/Python/Stackdriver.md
+++ b/content/exporters/supported-exporters/Python/Stackdriver.md
@@ -1,0 +1,70 @@
+---
+title: "Stackdriver (Tracing)"
+date: 2018-07-22T23:47:14-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/python/stackdriver]
+logo: /images/logo_gcp_vertical_rgb.png
+---
+
+- [Introduction](#introduction)
+- [Creating the exporters](#creating-the-exporters)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+Stackdriver Trace is a distributed tracing system that collects latency data from your applications and displays it in the Google Cloud Platform Console.
+
+You can track how requests propagate through your application and receive detailed near real-time performance insights.
+Stackdriver Trace automatically analyzes all of your application's traces to generate in-depth latency reports to surface performance degradations, and can capture traces from all of your VMs, containers, or Google App Engine projects.
+
+Stackdriver Monitoring provides visibility into the performance, uptime, and overall health of cloud-powered applications.
+Stackdriver collects metrics, events, and metadata from Google Cloud Platform, Amazon Web Services, hosted uptime probes, application instrumentation, and a variety of common application components including Cassandra, Nginx, Apache Web Server, Elasticsearch, and many others.
+
+Stackdriver ingests that data and generates insights via dashboards, charts, and alerts. Stackdriver alerting helps you collaborate by
+integrating with Slack, PagerDuty, HipChat, Campfire, and more.
+
+OpenCensus Python has support for this exporter available through package:
+* Trace [opencensus.trace.exporters.stackdriver_exporter](https://census-instrumentation.github.io/opencensus-python/trace/api/stackdriver_exporter.html)
+
+{{% notice tip %}}
+For assistance setting up Stackdriver, [Click here](/codelabs/stackdriver) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporters
+To create the exporters, you'll need to:
+
+* Have a GCP Project ID
+* Have already enabled Stackdriver Tracing and Metrics, if not, please visit the [Code lab](/codelabs/stackdriver)
+* Create the exporters in code
+
+Instrument your code with the following snippet:
+
+{{<highlight python>}}
+#!/usr/bin/env python
+
+import os
+
+from opencensus.trace.tracer import Tracer
+from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.trace.exporters.transports.background_thread import BackgroundThreadTransport
+
+def main():
+    sde = stackdriver_exporter.StackdriverExporter(
+                project_id=os.environ.get("GCP_PROJECT_ID"),
+                transport=BackgroundThreadTransport)
+
+    tracer = Tracer(exporter=sde)
+    with tracer.span(name='doingWork') as span:
+        for i in range(10):
+            continue
+
+if __name__ == "__main__":
+    main()
+{{</highlight>}}
+
+## Viewing your metrics
+Please visit [https://console.cloud.google.com/monitoring](https://console.cloud.google.com/monitoring)
+
+## Viewing your traces
+Please visit [https://console.cloud.google.com/traces/traces](https://console.cloud.google.com/traces/traces)

--- a/content/exporters/supported-exporters/Python/Zipkin.md
+++ b/content/exporters/supported-exporters/Python/Zipkin.md
@@ -1,0 +1,58 @@
+---
+title: "Zipkin (Tracing)"
+date: 2018-07-22T23:12:15-07:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/python/zipkin]
+logo: /img/zipkin-logo.jpg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your traces](#viewing-your-traces)
+- [Project link](#project-link)
+
+## Introduction
+Zipkin is a distributed tracing system. It helps gather timing data needed to troubleshoot latency problems in microservice architectures.
+
+It manages both the collection and lookup of this data. Zipkin’s design is based on the Google Dapper paper.
+
+OpenCensus Python has support for this exporter available through package [opencensus.trace.exporters.zipkin_exporter](https://census-instrumentation.github.io/opencensus-python/trace/api/zipkin_exporter.html)
+
+{{% notice tip %}}
+For assistance setting up Zipkin, [Click here](/codelabs/zipkin) for a guided codelab.
+{{% /notice %}}
+
+## Creating the exporter
+To create the exporter, we'll need to:
+
+* Create an exporter in code
+* Have the Zipkin endpoint available to receive traces
+
+{{<highlight python>}}
+#!/usr/bin/env python
+
+from opencensus.trace.exporters.zipkin_exporter import ZipkinExporter
+from opencensus.trace.tracer import Tracer
+
+def main():
+    ze = ZipkinExporter(service_name="service-a",
+                        host_name='localhost',
+                        port=9411,
+                        endpoint='/api/v2/spans')
+
+    tracer = Tracer(exporter=ze)
+    with tracer.span(name='doingWork') as span:
+        for i in range(10):
+            continue
+
+if __name__ == "__main__":
+    main()
+{{</highlight>}}
+
+## Viewing your traces
+Please visit the Zipkin UI endpoint [http://localhost:9411](http://localhost:9411)
+
+## Project link
+You can find out more about the Zipkin project at [https://zipkin.io/](https://zipkin.io/)

--- a/content/exporters/supported-exporters/Python/_index.md
+++ b/content/exporters/supported-exporters/Python/_index.md
@@ -1,0 +1,13 @@
+---
+title: "Python"
+date: 2018-07-22T23:12:15-07:00
+draft: false
+weight: 2
+class: "resized-logo"
+aliases: [/supported-exporters/python]
+logo: /images/python-opencensus.png
+---
+
+OpenCensus Python provides support for various exporters like:
+
+{{% children %}}

--- a/content/exporters/supported-exporters/_index.md
+++ b/content/exporters/supported-exporters/_index.md
@@ -1,0 +1,18 @@
+---
+title: "Supported Exporters"
+date: 2018-07-21T14:27:35-07:00
+draft: false
+weight: 50
+aliases: [/supported-exporters]
+---
+
+OpenCensus' language implementations have support for various exporters.
+
+<abbr class="trace-exporter blue white-text">T</abbr> Tracing guide available
+
+<abbr class="stats-exporter teal white-text">S</abbr> Stats guide available
+
+{{<card-exporter target-url="go" src="/images/gopher.png" lang="Go" tracing="true" stats="true">}}
+{{<card-exporter target-url="java" src="/images/java-icon.png" lang="Java" tracing="true" stats="true">}}
+{{<card-exporter target-url="python" src="/images/python-icon.png" lang="Python" tracing="true">}}
+{{<card-exporter target-url="node.js" src="/images/nodejs.png" lang="Node" tracing="true" stats="true">}}


### PR DESCRIPTION
The exporters files were relocated to
    content/exporters
from
    content/guides/exporters
but unfortunately a rebase nuked the newly relocated files

This change brings them back, nothing has changed except for a revival.