### PR TITLE
content/stats: views.md -> view.md

### DIFF
--- a/content/stats/view.md
+++ b/content/stats/view.md
@@ -1,7 +1,7 @@
 ---
 title: "View"
 weight: 3
-aliases: [/core-concepts/metrics/views]
+aliases: [/core-concepts/metrics/views, /stats/views]
 ---
 
 - [View](#view)


### PR DESCRIPTION
The /stats/views page really should be /stats/view.
This change fixes that but also adds an alias to /stats/view
of /stats/views

Fixes #419