### PR TITLE
exporters/{Go, Java}: update URL aliases

### DIFF
--- a/content/exporters/supported-exporters/Go/ApplicationInsights.md
+++ b/content/exporters/supported-exporters/Go/ApplicationInsights.md
@@ -4,7 +4,7 @@ date: 2018-10-22
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/applicationinsights]
+aliases: [/supported-exporters/go/applicationinsights, /guides/exporters/supported-exporters/go/applicationinsights]
 logo: /img/partners/microsoft_logo.svg
 ---
 

--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/datadog]
+aliases: [/supported-exporters/go/datadog, /guides/exporters/supported-exporters/go/datadog]
 logo: /img/partners/datadog_logo.svg
 ---
 

--- a/content/exporters/supported-exporters/Go/Honeycomb.md
+++ b/content/exporters/supported-exporters/Go/Honeycomb.md
@@ -4,7 +4,7 @@ date: 2018-10-16
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/honeycomb]
+aliases: [/guides/exporters/supported-exporters/go/honeycomb]
 logo: /img/honeycomb-logo.jpg
 ---
 

--- a/content/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/exporters/supported-exporters/Go/Jaeger.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/jaeger]
+aliases: [/supported-exporters/jaeger, /guides/exporters/supported-exporters/go/jaeger]
 logo: /img/partners/jaeger_logo.svg
 ---
 

--- a/content/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/exporters/supported-exporters/Go/Prometheus.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/prometheus]
+aliases: [/supported-exporters/go/prometheus, /guides/exporters/supported-exporters/go/prometheus]
 logo: /img/prometheus-logo.png
 ---
 

--- a/content/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/exporters/supported-exporters/Go/Stackdriver.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/stackdriver]
+aliases: [/supported-exporters/go/stackdriver, /guides/exporters/supported-exporters/go/stackdriver]
 logo: /images/logo_gcp_vertical_rgb.png
 ---
 

--- a/content/exporters/supported-exporters/Go/XRay.md
+++ b/content/exporters/supported-exporters/Go/XRay.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/xray]
+aliases: [/supported-exporters/go/xray, /guides/exporters/supported-exporters/go/xray]
 logo: https://d1.awsstatic.com/product-marketing/X-Ray/x-ray_web-app_diagram_light.21c38e4500dca09b3c8ca4cf87f896f7bbfb8a3b.png
 ---
 

--- a/content/exporters/supported-exporters/Go/Zipkin.md
+++ b/content/exporters/supported-exporters/Go/Zipkin.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/go/zipkin]
+aliases: [/supported-exporters/go/zipkin, /guides/exporters/supported-exporters/go/zipkin]
 logo: /img/zipkin-logo.jpg
 ---
 

--- a/content/exporters/supported-exporters/Go/_index.md
+++ b/content/exporters/supported-exporters/Go/_index.md
@@ -4,7 +4,7 @@ date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 2
 class: "resized-logo"
-aliases: [/supported-exporters/go]
+aliases: [/guides/exporters/supported-exporters/go]
 logo: /images/gopher.png
 ---
 

--- a/content/exporters/supported-exporters/Java/Instana.md
+++ b/content/exporters/supported-exporters/Java/Instana.md
@@ -4,7 +4,7 @@ date: 2018-07-21T18:52:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/instana]
+aliases: [/supported-exporters/instana, /guides/exporters/supported-exporters/java/instana]
 logo: /images/instana.png
 ---
 

--- a/content/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/exporters/supported-exporters/Java/Jaeger.md
@@ -4,7 +4,7 @@ date: 2018-07-22T17:35:15-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/jaeger]
+aliases: [/supported-exporters/jaeger, /guides/exporters/supported-exporters/java/jaeger]
 logo: /img/partners/jaeger_logo.svg
 ---
 

--- a/content/exporters/supported-exporters/Java/Prometheus.md
+++ b/content/exporters/supported-exporters/Java/Prometheus.md
@@ -4,7 +4,7 @@ date: 2018-07-22T14:27:35-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/java/prometheus]
+aliases: [/supported-exporters/java/prometheus, /guides/exporters/supported-exporters/java/prometheus]
 logo: /img/prometheus-logo.png
 ---
 

--- a/content/exporters/supported-exporters/Java/SignalFx.md
+++ b/content/exporters/supported-exporters/Java/SignalFx.md
@@ -4,7 +4,7 @@ date: 2018-07-22T16:58:03-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/java/signalfx]
+aliases: [/supported-exporters/java/signalfx, /guides/exporters/supported-exporters/java/signalfx]
 logo: /img/partners/signalFx_logo.svg
 ---
 

--- a/content/exporters/supported-exporters/Java/Zipkin.md
+++ b/content/exporters/supported-exporters/Java/Zipkin.md
@@ -4,7 +4,7 @@ date: 2018-07-22T17:20:12-07:00
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/supported-exporters/java/zipkin]
+aliases: [/supported-exporters/java/zipkin, /guides/exporters/supported-exporters/java/zipkin]
 logo: /img/zipkin-logo.jpg
 ---
 

--- a/content/exporters/supported-exporters/Java/_index.md
+++ b/content/exporters/supported-exporters/Java/_index.md
@@ -4,7 +4,7 @@ date: 2018-07-21T18:40:01-02:00
 draft: false
 weight: 2
 class: "resized-logo"
-aliases: [/supported-exporters/java]
+aliases: [/supported-exporters/java, /guides/exporters/supported-exporters/java]
 logo: /images/java.png
 ---
 

--- a/content/exporters/supported-exporters/Java/stackdriver-stats.md
+++ b/content/exporters/supported-exporters/Java/stackdriver-stats.md
@@ -3,7 +3,7 @@ title: "Stackdriver (Stats)"
 date: 2018-10-26T14:27:35-07:00
 draft: false
 class: "shadowed-image lightbox"
-aliases: [/supported-exporters/java/stackdriver]
+aliases: [/guides/exporters/supported-exporters/java/stackdriver-stats]
 logo: /images/logo_gcp_vertical_rgb.png
 ---
 

--- a/content/exporters/supported-exporters/Java/stackdriver-trace.md
+++ b/content/exporters/supported-exporters/Java/stackdriver-trace.md
@@ -3,7 +3,7 @@ title: "Stackdriver (Tracing)"
 date: 2018-07-21T14:27:35-07:00
 draft: false
 class: "shadowed-image lightbox"
-aliases: [/supported-exporters/java/stackdriver]
+aliases: [/guides/exporters/supported-exporters/java/stackdriver-trace]
 logo: /images/logo_gcp_vertical_rgb.png
 ---
 

--- a/content/exporters/supported-exporters/_index.md
+++ b/content/exporters/supported-exporters/_index.md
@@ -3,7 +3,7 @@ title: "Supported Exporters"
 date: 2018-07-21T14:27:35-07:00
 draft: false
 weight: 50
-aliases: [/supported-exporters]
+aliases: [/supported-exporters, /guides/exporters/supported-exporters]
 ---
 
 OpenCensus' language implementations have support for various exporters.


### PR DESCRIPTION
Update URL aliases to ensure that the old links are
routed to the proper current location and don't 404

Updates #423