### PR TITLE
exporter/custom_exporter/*: add URL aliases

### DIFF
--- a/content/exporters/custom-exporter/Cpp/Tracing.md
+++ b/content/exporters/custom-exporter/Cpp/Tracing.md
@@ -2,6 +2,7 @@
 title: "Trace exporter"
 date: 2018-10-22T17:31:12-07:00
 draft: false
+aliases: [/custom_exporter/cpp/tracing, /guides/exporters/custom-exporter/cpp/tracing]
 class: "shadowed-image lightbox"
 ---
 

--- a/content/exporters/custom-exporter/Cpp/_index.md
+++ b/content/exporters/custom-exporter/Cpp/_index.md
@@ -3,6 +3,7 @@ title: "C++"
 draft: false
 weight: 3
 class: "resized-logo"
+aliases: [/custom_exporter/cpp, /guides/exporters/custom-exporter/cpp]
 logo: /images/cpp-opencensus.png
 ---
 

--- a/content/exporters/custom-exporter/Go/Metrics.md
+++ b/content/exporters/custom-exporter/Go/Metrics.md
@@ -2,7 +2,7 @@
 title: "Metrics exporter"
 draft: false
 weight: 3
-aliases: [/custom_exporter/go/metrics]
+aliases: [/custom_exporter/go/metrics, /guides/exporters/custom-exporter/go/metrics]
 ---
 
 - [Introduction](#introduction)

--- a/content/exporters/custom-exporter/Go/Trace.md
+++ b/content/exporters/custom-exporter/Go/Trace.md
@@ -2,7 +2,7 @@
 title: "Trace exporter"
 draft: false
 weight: 3
-aliases: [/custom_exporter/go/trace]
+aliases: [/custom_exporter/go/trace, /guides/exporters/custom-exporter/go/trace]
 ---
 
 - [Introduction](#introduction)

--- a/content/exporters/custom-exporter/Go/_index.md
+++ b/content/exporters/custom-exporter/Go/_index.md
@@ -3,6 +3,7 @@ title: "Go"
 draft: false
 weight: 3
 class: "resized-logo"
+aliases: [/custom_exporter/go, /guides/exporters/custom-exporter/go]
 logo: /images/gopher.png
 ---
 

--- a/content/exporters/custom-exporter/Java/Trace.md
+++ b/content/exporters/custom-exporter/Java/Trace.md
@@ -2,7 +2,7 @@
 title: "Trace exporter"
 draft: false
 weight: 3
-aliases: [/custom_exporter/java/trace]
+aliases: [/custom_exporter/java/trace, /guides/custom_exporter/java/trace]
 ---
 
 - [Introduction](#introduction)

--- a/content/exporters/custom-exporter/Java/_index.md
+++ b/content/exporters/custom-exporter/Java/_index.md
@@ -3,7 +3,7 @@ title: "Java"
 draft: false
 weight: 3
 class: "resized-logo"
-aliases: [/custom_exporter/java]
+aliases: [/custom_exporter/java, /guides/custom_exporter/java]
 logo: /images/java.png
 ---
 

--- a/content/exporters/custom-exporter/Node.js/Metrics.md
+++ b/content/exporters/custom-exporter/Node.js/Metrics.md
@@ -2,6 +2,7 @@
 title: "Stats exporter"
 draft: false
 weight: 3
+aliases: [/custom_exporter/nodejs/metrics, /custom_exporter/node.js/metrics, /guides/exporters/custom-exporter/nodejs/metrics, /guides/exporters/custom-exporter/node.js/metrics]
 ---
 
 ### Table of contents

--- a/content/exporters/custom-exporter/Node.js/Trace.md
+++ b/content/exporters/custom-exporter/Node.js/Trace.md
@@ -2,6 +2,7 @@
 title: "Trace exporter"
 draft: false
 weight: 3
+aliases: [/custom_exporter/nodejs/trace, /custom_exporter/node.js/trace, /guides/exporters/custom-exporter/nodejs/trace, /guides/exporters/custom-exporter/node.js/trace]
 ---
 
 ### Table of contents

--- a/content/exporters/custom-exporter/Node.js/_index.md
+++ b/content/exporters/custom-exporter/Node.js/_index.md
@@ -3,6 +3,7 @@ title: "Node.js"
 draft: false
 weight: 3
 class: "resized-logo"
+aliases: [/custom_exporter/nodejs, /custom_exporter/node.js, /guides/exporters/custom-exporter/nodejs, /guides/exporters/custom-exporter/node.js]
 logo: /images/nodejs.png
 ---
 

--- a/content/exporters/custom-exporter/_index.md
+++ b/content/exporters/custom-exporter/_index.md
@@ -3,7 +3,7 @@ title: "Writing a custom exporter"
 draft: false
 weight: 56
 class: "resized-logo"
-aliases: [/custom_exporter]
+aliases: [/custom_exporter, /guides/exporters/custom-exporter]
 logo: /images/opencensus-logo.png
 ---
 


### PR DESCRIPTION
Added URL aliases for the "How to write a custom exporter"
pages for all the languages and pages underneath.

Updates #423