### PR TITLE
Update quickstart page to correctly link to metrics page

### DIFF
--- a/content/quickstart/_index.md
+++ b/content/quickstart/_index.md
@@ -7,7 +7,7 @@ weight: 2
 
 By completing this quickstart, you will learn how to:
 
-* Collect [metrics](/metrics) from your services
+* Collect [metrics](/stats) from your services
 * [Trace](/tracing) a request as it passes through your services
 * [Export](/exporters) your data to one of our [supported backends](/guides/exporters/supported-exporters/)
 


### PR DESCRIPTION
Currently the quickstart page links to /metrics, which results in a 404.  This change will link to /stats, which seems to be the appropriate documentation.