### PR TITLE
Add missing import for opencensus tag package

### DIFF
--- a/content/stats/view.md
+++ b/content/stats/view.md
@@ -43,6 +43,7 @@ package main
 
 import (
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 func enableViews() error {


### PR DESCRIPTION
Currently, the go code snippit in the stats -> view page is missing an import for the opencensus tag package.  This change adds the correct import.