### PR TITLE
content/conduct: add CoC verbatim

### DIFF
--- a/content/community/_index.md
+++ b/content/community/_index.md
@@ -17,4 +17,4 @@ Any questions or suggestions? You can reach us via email: [census-developers@goo
 Join other developers and users on the OpenCensus [Gitter channel](https://gitter.im/census-instrumentation/Lobby).
 
 #### Code of Conduct
-The OpenCensus community values respect and inclusiveness, and enforces a [Code of Conduct](https://github.com/census-instrumentation/opencensus-specs/blob/master/code-of-conduct.md) in all interactions.
+The OpenCensus community values respect and inclusiveness, and enforces a [Code of Conduct](/conduct) in all interactions.

--- a/content/conduct/_index.md
+++ b/content/conduct/_index.md
@@ -1,0 +1,54 @@
+---
+title: "Code of conduct"
+date: 2018-11-14T16:28:00-07:00
+draft: false
+weight: 150
+---
+
+- [Our pledge](#our-pledge)
+- [Our Standards and Values](#our-standards-and-values)
+- [Our Responsibilities](#our-responsibilities)
+- [Scope](#scope)
+- [Enforcement](#enforcement)
+- [Attribution](#attribution)
+
+#### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers of OpenCensus pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation. People violating this code of conduct may be banned from the community and all its events.
+
+#### Our Standards and Values
+
+- Be friendly and patient: Remember you might not be communicating in someone else's primary spoken or programming language, and others may not have your level of understanding.
+- Be welcoming: Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- Be respectful: We are a world-wide community of professionals, and we conduct ourselves professionally. Disagreement is no excuse for poor behavior and poor manners. Disrespectful and unacceptable behavior includes, but is not limited to:
+    - Violent threats or language.
+    - Discriminatory or derogatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting, or threatening to post, people's personally identifying information ("doxing").
+    - Insults, especially those using discriminatory terms or slurs.
+    - Behavior that could be perceived as sexual attention.
+    - Advocating for or encouraging any of the above behaviors.
+	
+- Understand disagreements: Disagreements, both social and technical, are useful learning opportunities. Seek to understand the other viewpoints and resolve differences constructively.
+- This code is not exhaustive or complete. It serves to capture our common understanding of a productive, collaborative environment. We expect the code to be followed in spirit as much as in the letter.
+
+#### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+#### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+#### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at *census-developers@googlegroups.com* . All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
+
+### Attribution
+
+This code of conduct is based the [Contributor Covenant version 1.4](http://contributor-covenant.org/version/1/4/). The ‘Our Standards’ section is based off of the Microsoft Inc’s [Code of Conduct](https://opensource.microsoft.com/codeofconduct/)


### PR DESCRIPTION
Added a page `/conduct` with our Code of Conduct verbatim
instead of just as a link to the specs.
The website serves the entry point and representation of the
project to both technical and non-technical audiences.

A specialized endpoint makes linking easy but also direct
and shows the project's committment to a code of conduct.

Fixes #436