### PR TITLE
Add 'Edit this page on Github' link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -29,7 +29,7 @@ theme = "docdock"
 
 [params]
 description = "A stats collection and distributed tracing framework"
-editURL = "https://github.com/vjeantet/hugo-theme-docdock/edit/master/exampleSite/content/"
+editURL = "https://github.com/census-instrumentation/opencensus-website/edit/master/content/"
 showVisitedLinks = true # default is false
 themeStyle = "flex" # "original" or "flex" # default "flex"
 themeVariant = "" # choose theme variant "green", "gold" , "gray", "blue" (default)

--- a/themes/docdock/i18n/en.toml
+++ b/themes/docdock/i18n/en.toml
@@ -35,7 +35,7 @@ other = "Woops. Looks like this page doesn't exist."
 other = "Go to homepage"
 
 [Edit-this-page]
-other = "Improve this page"
+other = "Edit this page on Github"
 
 [Expand-title]
 other = "Expand me..."

--- a/themes/docdock/layouts/partials/flex/body-aftercontent.html
+++ b/themes/docdock/layouts/partials/flex/body-aftercontent.html
@@ -24,14 +24,14 @@
 
   <!-- {{ if not .Page.Lastmod.IsZero }}
     <div class="date">
-        <i class='fa fa-calendar'></i> {{T "last-update-on"}} {{ .Page.Lastmod.Format "02/01/2006" }}
+        <i class='fa fa-calendar'></i> {{T "last-update-on"}} {{ .Page.Lastmod.Format "2006/01/02" }}
     </div>
-    {{end}}
+    {{end}} -->
 
     <div class="github-link">
       <a href="{{ .Site.Params.editURL }}{{ replace .File.Dir "\\" "/" }}{{ .File.LogicalName }}" target="blank"><i class="fa fa-code-fork"></i>
         {{T "Edit-this-page"}}</a>
-    </div> -->
+    </div>
   </div>
 
 


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-website/issues/428

![screen shot 2018-11-17 at 9 17 07 am](https://user-images.githubusercontent.com/5974764/48663756-964de680-ea49-11e8-96f0-8902d86be0bd.png)

Clicking on that takes to you to an edit page on Github:
![screen shot 2018-11-17 at 9 17 40 am](https://user-images.githubusercontent.com/5974764/48663765-b54c7880-ea49-11e8-88b0-266f11ee420f.png)

Note: Original English text was "Improve this Page" and I changed that to "Edit this page on Github." There are other localizations included that I did not change as I didn't want to provide a false translation.