### PR TITLE
Fix missing err short assignment in Go Metrics

### DIFF
--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -410,7 +410,7 @@ and for complete usage:
 {{% tabs Snippet All %}}
 ```go
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -481,7 +481,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -603,7 +603,7 @@ Now we will record the desired metrics. To do so, we will use `stats.Record` and
 {{% tabs Snippet All %}}
 ```go
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -702,7 +702,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -826,7 +826,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -987,7 +987,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -1148,7 +1148,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}
@@ -1373,7 +1373,7 @@ func main() {
 // readEvaluateProcess reads a line from the input reader and
 // then processes it. It returns an error if any was encountered.
 func readEvaluateProcess(br *bufio.Reader) (terr error) {
-	ctx, _ := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
+	ctx, err := tag.New(context.Background(), tag.Insert(KeyMethod, "repl"), tag.Insert(KeyStatus, "OK"))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It seems that `err` is not declared properly for some of the code snippets. It seems that it was removed in https://github.com/census-instrumentation/opencensus-website/pull/484/ .

Some of the other changes also seemed unnecessary for some functions (like naming the error return value `(terr error)` but not using `terr`). One change that may want to be investigated further is:

https://github.com/census-instrumentation/opencensus-website/pull/484/files#diff-4d73bb710d0b193312291ce07a0b156cL620

where the `log.Fatal(err)` replaces `return err`. The `log.Fatal` will cause a panic and I believe does not work correctly with the intended behavior in line 686 ( https://github.com/census-instrumentation/opencensus-website/pull/484/files#diff-4d73bb710d0b193312291ce07a0b156cL686 ) where any returned error is checked to be `io.EOF` and normally returns.