### PR TITLE
integrations/*/spanner: fix Go package URL, lists

### DIFF
--- a/content/guides/integrations/google_cloud/google_cloud_spanner/Go.md
+++ b/content/guides/integrations/google_cloud/google_cloud_spanner/Go.md
@@ -20,8 +20,9 @@ logo: /images/gopher.png
 
 ## Introduction
 Cloud Spanner's Go package was already instrumented for:
+
 * Tracing with OpenCensus
-* Metrics with gRPC
+* Metrics with OpenCensus by way of gRPC metrics
 
 {{% notice note %}}
 This guide makes use of a couple of APIs
@@ -38,7 +39,7 @@ For tracing and metrics on Spanner, we'll import a couple of packages
 
 Package Name|Package link
 ---|---
-The Cloud Spanner Go package|[cloud.google.com/spanner](https://godoc.org/cloud.google.com/spanner)
+The Cloud Spanner Go package|[cloud.google.com/go/spanner](https://godoc.org/cloud.google.com/go/spanner)
 The OpenCensus trace package|[go.opencensus.io/trace](https://godoc.org/go.opencensus.io/trace)
 The OpenCensus metrics views package|[go.opencensus.io/stats](https://godoc.org/go.opencensus.io/stats)
 The OpenCensus gRPC plugin|[go.opencensus.io/plugin/ocgrpc](https://godoc.org/go.opencensus.io/plugin/ocgrpc)

--- a/content/guides/integrations/google_cloud/google_cloud_spanner/Java.md
+++ b/content/guides/integrations/google_cloud/google_cloud_spanner/Java.md
@@ -22,8 +22,9 @@ logo: /images/java.png
 
 ## Introduction
 Cloud Spanner's Java package was already instrumented for:
+
 * Tracing with OpenCensus
-* Metrics with gRPC
+* Metrics with OpenCensus by way of gRPC metrics
 
 {{% notice note %}}
 This guide makes use of a couple of APIs


### PR DESCRIPTION
* The Go package URL was mistakenly
    cloud.google.com/spanner
instead of
    cloud.google.com/go/spanner

* In the Introduction section for both Go and Java,
the listings were next to the first sentence hence
weren't correctly rendered

* Mention that the metrics are provided by gRPC and OpenCensus