### PR TITLE
content/quickstarts/node/metrics: Extract latency measurement outside of try/catch

### DIFF
--- a/content/quickstart/nodejs/metrics.md
+++ b/content/quickstart/nodejs/metrics.md
@@ -342,9 +342,9 @@ Now we will record the desired metrics. To do so, we will use `stats.record()` a
 {{<tabs Snippet All>}}
 {{<highlight javascript>}}
 lineReader.on("line", function (line) {
+    const tags = {method: "repl", status: "OK"};
     try {
         // ...
-        const tags = {method: "repl", status: "OK"};
 
         stats.record({
           measure: mLineLengths,
@@ -426,14 +426,13 @@ let endTime;
 
 // REPL is the read, evaluate, print and loop
 lineReader.on("line", function (line) {       // Read
+  const tags = {method: "repl", status: "OK"};
   try {
     const processedLine = processLine(line);    // Evaluate
     console.log(processedLine);                // Print
 
     // Registers the end of our REPL
     endTime = new Date();
-
-    const tags = {method: "repl", status: "OK"};
 
     stats.record({
       measure: mLineLengths,
@@ -556,14 +555,13 @@ let startTime = new Date();
 let endTime;
 // REPL is the read, evaluate, print and loop
 lineReader.on("line", function (line) {       // Read
+  const tags = {method: "repl", status: "OK"};
   try {
     const processedLine = processLine(line);    // Evaluate
     console.log(processedLine);                // Print
 
     // Registers the end of our REPL
     endTime = new Date();
-
-    const tags = {method: "repl", status: "OK"};
 
     stats.record({
       measure: mLineLengths,

--- a/content/quickstart/nodejs/metrics.md
+++ b/content/quickstart/nodejs/metrics.md
@@ -342,28 +342,30 @@ Now we will record the desired metrics. To do so, we will use `stats.record()` a
 {{<tabs Snippet All>}}
 {{<highlight javascript>}}
 lineReader.on("line", function (line) {
-    const tags = {method: "repl", status: "OK"};
-    try {
-        // ...
+  // Registers the Tags for our measurements
+  const tags = {method: "repl", status: "OK"};
 
-        stats.record({
-          measure: mLineLengths,
-          tags,
-          value: processedLine.length
-        });
-    } catch (err) {
-        tags.status = "ERROR";
-        tags.error = err.message;
-    }
+  try {
+    // ...
 
     stats.record({
-      measure: mLatencyMs,
+      measure: mLineLengths,
       tags,
-      value: endTime.getTime() - startTime.getTime()
+      value: processedLine.length
     });
+  } catch (err) {
+    tags.status = "ERROR";
+    tags.error = err.message;
+  }
 
-    // Restarts the start time for the REPL
-    startTime = endTime;
+  stats.record({
+    measure: mLatencyMs,
+    tags,
+    value: (new Date()) - startTime.getTime()
+  });
+
+  // Restarts the start time for the REPL
+  startTime = new Date();
 });
 {{</highlight>}}
 
@@ -426,13 +428,12 @@ let endTime;
 
 // REPL is the read, evaluate, print and loop
 lineReader.on("line", function (line) {       // Read
+  // Registers the Tags for our measurements
   const tags = {method: "repl", status: "OK"};
+
   try {
     const processedLine = processLine(line);    // Evaluate
     console.log(processedLine);                // Print
-
-    // Registers the end of our REPL
-    endTime = new Date();
 
     stats.record({
       measure: mLineLengths,
@@ -447,11 +448,11 @@ lineReader.on("line", function (line) {       // Read
   stats.record({
     measure: mLatencyMs,
     tags,
-    value: endTime.getTime() - startTime.getTime()
+    value: (new Date()) - startTime.getTime()
   });
 
   // Restarts the start time for the REPL
-  startTime = endTime;
+  startTime = new Date();
 });
 
 /**
@@ -555,13 +556,12 @@ let startTime = new Date();
 let endTime;
 // REPL is the read, evaluate, print and loop
 lineReader.on("line", function (line) {       // Read
+  // Registers the Tags for our measurements
   const tags = {method: "repl", status: "OK"};
+
   try {
     const processedLine = processLine(line);    // Evaluate
     console.log(processedLine);                // Print
-
-    // Registers the end of our REPL
-    endTime = new Date();
 
     stats.record({
       measure: mLineLengths,
@@ -576,11 +576,11 @@ lineReader.on("line", function (line) {       // Read
   stats.record({
     measure: mLatencyMs,
     tags,
-    value: endTime.getTime() - startTime.getTime()
+    value: (new Date()) - startTime.getTime()
   });
 
   // Restarts the start time for the REPL
-  startTime = endTime;
+  startTime = new Date();
 });
 
 /**

--- a/content/quickstart/nodejs/metrics.md
+++ b/content/quickstart/nodejs/metrics.md
@@ -351,19 +351,16 @@ lineReader.on("line", function (line) {
           tags,
           value: processedLine.length
         });
-
-        stats.record({
-          measure: mLatencyMs,
-          tags,
-          value: endTime.getTime() - startTime.getTime()
-        });
     } catch (err) {
-        stats.record({
-          measure: mLatencyMs,
-          {method: "repl", status: "ERROR", error: err.message},
-          value: (new Date()) - startTime.getTime()
-        });
+        tags.status = "ERROR";
+        tags.error = err.message;
     }
+
+    stats.record({
+      measure: mLatencyMs,
+      tags,
+      value: endTime.getTime() - startTime.getTime()
+    });
 
     // Restarts the start time for the REPL
     startTime = endTime;
@@ -443,19 +440,16 @@ lineReader.on("line", function (line) {       // Read
       tags,
       value: processedLine.length
     });
-
-    stats.record({
-      measure: mLatencyMs,
-      tags,
-      value: endTime.getTime() - startTime.getTime()
-    });
   } catch (err) {
-    stats.record({
-      measure: mLatencyMs,
-      {method: "repl", status: "ERROR", error: err.message},
-      value: (new Date()) - startTime.getTime()
-    });
+      tags.status = "ERROR";
+      tags.error = err.message;
   }
+
+  stats.record({
+    measure: mLatencyMs,
+    tags,
+    value: endTime.getTime() - startTime.getTime()
+  });
 
   // Restarts the start time for the REPL
   startTime = endTime;
@@ -576,19 +570,16 @@ lineReader.on("line", function (line) {       // Read
       tags,
       value: processedLine.length
     });
-
-    stats.record({
-      measure: mLatencyMs,
-      tags,
-      value: endTime.getTime() - startTime.getTime()
-    });
   } catch (err) {
-    stats.record({
-      measure: mLatencyMs,
-      {method: "repl", status: "ERROR", error: err.message},
-      value: (new Date()) - startTime.getTime()
-    });
+      tags.status = "ERROR";
+      tags.error = err.message;
   }
+
+  stats.record({
+    measure: mLatencyMs,
+    tags,
+    value: endTime.getTime() - startTime.getTime()
+  });
 
   // Restarts the start time for the REPL
   startTime = endTime;


### PR DESCRIPTION
Thanks to a nice catch by @odeke-em, this PR prevents a possible double-measurement from happening.