### PR TITLE
"pyton" => "python"

### DIFF
--- a/layouts/shortcodes/feature-matrix.html
+++ b/layouts/shortcodes/feature-matrix.html
@@ -45,7 +45,7 @@
 		<td>Datadog</td>
 		<td data-label="csharp">–</td>
 		<td data-label="cpp">–</td>
-		<td data-label="erlang">–</td>
+		<td data-label="erlang"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr> <abbr title="Stats Exporter" class="stats-exporter teal white-text">S</abbr></td>
 		<td data-label="golang"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr> <abbr title="Stats Exporter" class="stats-exporter teal white-text">S</abbr></td>
 		<td data-label="java">–</td>
 		<td data-label="nodejs">–</td>


### PR DESCRIPTION
fixing typo "pyton" => "python"