### PR TITLE
datadog.NewExporter returns an *Exporter only

### DIFF
--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -48,10 +48,7 @@ import (
 )
 
 func main() {
-  dd, err := datadog.NewExporter(datadog.Options{})
-  if err != nil {
-    log.Fatalf("Failed to create the Datadog exporter: %v", err)
-  }
+  dd := datadog.NewExporter(datadog.Options{})
   // It is imperative to invoke flush before your main function exits
   defer dd.Stop()
 


### PR DESCRIPTION
See example:
https://github.com/DataDog/opencensus-go-exporter-datadog/blob/master/examples/stats/main.go

For consistency (and perhaps practicality), their library should probably be revised return an error too.