### PR TITLE
guides/google_cloud_spanner: update dependencies + ensure compilation

### DIFF
--- a/content/guides/integrations/google_cloud/google_cloud_spanner/Java.md
+++ b/content/guides/integrations/google_cloud/google_cloud_spanner/Java.md
@@ -42,7 +42,8 @@ For tracing and metrics on Spanner, we'll import a couple of packages
 Package Name|Package link
 ---|---
 The Cloud Spanner Java package|[com.google.cloud.spanner](https://googlecloudplatform.github.io/google-cloud-java)
-The OpenCensus trace package|[io.opencensus.trace](https://www.javadoc.io/doc/io.opencensus/opencensus-trace)
+The OpenCensus trace package|[io.opencensus.trace](https://static.javadoc.io/io.opencensus/opencensus-api/0.18.0/io/opencensus/trace/package-frame.html)
+The OpenCensus stats package|[io.opencensus.stats](https://static.javadoc.io/io.opencensus/opencensus-api/0.18.0/io/opencensus/stats/package-frame.html)
 The OpenCensus Java gRPC views|[io.opencensus.contrib.grpc.metrics.RpcViews](https://github.com/census-instrumentation/opencensus-java/tree/master/contrib/grpc_metrics)
 
 And when imported in code:
@@ -76,117 +77,134 @@ With all the steps combined, we'll finally have this code snippet
 
 {{<tabs Source Pom_xml>}}
 {{<highlight java>}}
-package com.opencensus.examples;
+package com.opencensus.tutorials;
 
 import com.google.cloud.spanner.DatabaseClient;
 import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.Key;
 import com.google.cloud.spanner.Mutation;
-import com.google.cloud.spanner.ResultSet;
 import com.google.cloud.spanner.Spanner;
 import com.google.cloud.spanner.SpannerOptions;
-import com.google.cloud.spanner.Statement;
-
 import io.opencensus.common.Scope;
 import io.opencensus.contrib.grpc.metrics.RpcViews;
 import io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter;
+import io.opencensus.exporter.trace.stackdriver.StackdriverTraceConfiguration;
 import io.opencensus.exporter.trace.stackdriver.StackdriverTraceExporter;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.samplers.Samplers;
-
 import java.util.Arrays;
 import java.util.List;
 
 public class SpannerOpenCensusTutorial {
-    private DatabaseClient dbClient;
-    private Spanner spanner;
+  private DatabaseClient dbClient;
+  private Spanner spanner;
 
-    private static String parentSpanName = "create-players";
-    public SpannerOpenCensusTutorial(String instanceId, String databaseId) throws Exception {
-      // Instantiate the client.
-      SpannerOptions options = SpannerOptions.getDefaultInstance();
-      this.spanner = options.getService();
+  private static final String parentSpanName = "create-players";
 
-      // And then create the Spanner database client.
-      this.dbClient = this.spanner.getDatabaseClient(DatabaseId.of(
-          options.getProjectId(), instanceId, databaseId));
+  public SpannerOpenCensusTutorial(String instanceId, String databaseId) throws Exception {
+    // Instantiate the client.
+    SpannerOptions options = SpannerOptions.getDefaultInstance();
+    spanner = options.getService();
 
-      // Next up let's  install the exporter for Stackdriver tracing.
-      StackdriverTraceExporter.createAndRegister();
-      Tracing.getExportComponent().getSampledSpanStore()
-             .registerSpanNamesForCollection(Arrays.asList(parentSpanName));
+    // And then create the Spanner database client.
+    String projectId = options.getProjectId();
+    dbClient = spanner.getDatabaseClient(DatabaseId.of(projectId, instanceId, databaseId));
 
-      // Then the exporter for Stackdriver monitoring/metrics.
-      StackdriverStatsExporter.createAndRegister();
-      RpcViews.registerAllGrpcViews();
+    // Next up let's  install the exporter for Stackdriver tracing.
+    StackdriverTraceExporter.createAndRegister(
+        StackdriverTraceConfiguration.builder().setProjectId(projectId).build());
+
+    Tracing.getExportComponent()
+        .getSampledSpanStore()
+        .registerSpanNamesForCollection(Arrays.asList(parentSpanName));
+
+    // Then the exporter for Stackdriver monitoring/metrics.
+    StackdriverStatsExporter.createAndRegister();
+
+    // Finally register the gRPC views to give us metrics.
+    RpcViews.registerAllGrpcViews();
+  }
+
+  public void close() {
+    spanner.close();
+  }
+
+  public void warmUpRead() {
+    dbClient.singleUse().readRow("Players", Key.of("foo@gmail.com"), Arrays.asList("email"));
+  }
+
+  public static void main(String... args) throws Exception {
+    if (args.length < 2) {
+      System.err.println("Usage: ZeuSports <instance_id> <database_id>");
+      return;
     }
 
-    public void close() {
-      this.spanner.close();
-    }
+    try {
+      SpannerOpenCensusTutorial zdb = new SpannerOpenCensusTutorial(args[0], args[1]);
+      // Warm up the spanner client session. In normal usage
+      // you'd have hit this point after the first operation.
+      zdb.warmUpRead();
 
-    public void warmUpRead() {
-      this.dbClient.singleUse().readRow("Players", Key.of("foo@gmail.com"), Arrays.asList("email"));
-    }
+      for (int i = 0; i < 3; i++) {
+        String up = i + "-" + (System.currentTimeMillis() / 1000) + ".";
+        List<Mutation> mutations =
+            Arrays.asList(
+                playerMutation(
+                    "Poke",
+                    "Mon",
+                    up + "poke.mon@example.org",
+                    "f1578551-eb4b-4ecd-aee2-9f97c37e164e"),
+                playerMutation(
+                    "Go",
+                    "Census",
+                    up + "go.census@census.io",
+                    "540868a2-a1d8-456b-a995-b324e4e7957a"),
+                playerMutation(
+                    "Quick",
+                    "Sort",
+                    up + "q.sort@gmail.com",
+                    "2b7e0098-a5cc-4f32-aabd-b978fc6b9710"));
 
-    public static void main(String ...args) throws Exception {
-      if (args.length < 2) {
-        System.err.println("Usage: ZeuSports <instance_id> <database_id>");
-        return;
+        zdb.insertPlayers(mutations);
       }
 
-      try {
-        SpannerOpenCensusTutorial zdb = new SpannerOpenCensusTutorial(args[0], args[1]);
-	// Warm up the spanner client session. In normal usage
-	// you'd have hit this point after the first operation.
-	zdb.warmUpRead();
-
-	for (int i=0; i < 3; i++) {
-	  String up = i + "-" + (System.currentTimeMillis() / 1000) + ".";
-	  List<Mutation> mutations = Arrays.asList(
-	    playerMutation("Poke", "Mon", up + "poke.mon@example.org", "f1578551-eb4b-4ecd-aee2-9f97c37e164e"),
-	    playerMutation("Go", "Census", up + "go.census@census.io", "540868a2-a1d8-456b-a995-b324e4e7957a"),
-	    playerMutation("Quick", "Sort", up + "q.sort@gmail.com", "2b7e0098-a5cc-4f32-aabd-b978fc6b9710")
-	  );
-
-	  zdb.insertPlayers(mutations);
-	}
-
-        zdb.close();
-      } catch (Exception e) {
-        System.out.printf("Exception while adding player: " + e);
-      } finally {
-        System.out.println("Bye!");
-      }
+      zdb.close();
+    } catch (Exception e) {
+      System.out.printf("Exception while adding player: " + e);
+    } finally {
+      System.out.println("Bye!");
     }
+  }
 
-    public static Mutation playerMutation(String firstName, String lastName, String email, String uuid) {
-        return Mutation.newInsertBuilder("Players")
-          .set("first_name")
-          .to(firstName)
-          .set("last_name")
-          .to(lastName)
-          .set("uuid")
-          .to(uuid)
-          .set("email")
-          .to(email)
-          .build();
+  public static Mutation playerMutation(
+      String firstName, String lastName, String email, String uuid) {
+    return Mutation.newInsertBuilder("Players")
+        .set("first_name")
+        .to(firstName)
+        .set("last_name")
+        .to(lastName)
+        .set("uuid")
+        .to(uuid)
+        .set("email")
+        .to(email)
+        .build();
+  }
+
+  public void insertPlayers(List<Mutation> players) throws Exception {
+    try (Scope ss =
+        Tracing.getTracer()
+            .spanBuilderWithExplicitParent(parentSpanName, null)
+            // Enable the trace sampler.
+            //  We are always sampling for demo purposes only: this is a very high sampling
+            // rate, but sufficient for the purpose of this quick demo.
+            // More realistically perhaps tracing 1 in 10,000 might be more useful
+            .setSampler(Samplers.alwaysSample())
+            .startScopedSpan()) {
+
+      dbClient.write(players);
+    } finally {
     }
-
-    public void insertPlayers(List<Mutation> players) throws Exception {
-      try (Scope ss = Tracing.getTracer()
-        .spanBuilderWithExplicitParent(parentSpanName, null)
-        // Enable the trace sampler.
-        //  We are always sampling for demo purposes only: this is a very high sampling
-        // rate, but sufficient for the purpose of this quick demo.
-        // More realistically perhaps tracing 1 in 10,000 might be more useful
-        .setSampler(Samplers.alwaysSample())
-        .startScopedSpan()) {
-
-        this.dbClient.write(players);
-      } finally {
-      }
-    }
+  }
 }
 {{</highlight>}}
 
@@ -205,14 +223,15 @@ public class SpannerOpenCensusTutorial {
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <opencensus.version>0.11.0</opencensus.version>
+    <opencensus.version>0.18.0</opencensus.version>
+    <spanner.version>1.5.0</spanner.version>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-spanner</artifactId>
-      <version>0.33.0-beta</version>
+      <version>${spanner.version}</version>
       <exclusions>
 	<exclusion>
 	  <groupId>com.google.guava</groupId>
@@ -234,32 +253,32 @@ public class SpannerOpenCensusTutorial {
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-api</artifactId>
-      <version>0.11.0</version>
+      <version>${opencensus.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-stats-stackdriver</artifactId>
-      <version>0.11.0</version>
+      <version>${opencensus.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-exporter-trace-stackdriver</artifactId>
-      <version>0.11.0</version>
+      <version>${opencensus.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-contrib-grpc-metrics</artifactId>
-      <version>0.11.0</version>
+      <version>${opencensus.version}</version>
     </dependency>
 
 
     <dependency>
       <groupId>io.opencensus</groupId>
       <artifactId>opencensus-impl</artifactId>
-      <version>0.11.0</version>
+      <version>${opencensus.version}</version>
       <scope>runtime</scope>
     </dependency>
 
@@ -268,12 +287,13 @@ public class SpannerOpenCensusTutorial {
   <build>
     <plugins>
       <plugin>
-	<groupId>org.codehaus.mojo</groupId>
-	<artifactId>exec-maven-plugin</artifactId>
-	<version>1.4.0</version>
-	<configuration>
-	  <mainClass>com.opencensus.tutorials.spanner</mainClass>
-	</configuration>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.4.0</version>
+        <configuration>
+            <mainClass>com.opencensus.tutorials.SpannerOpenCensusTutorial</mainClass>
+            <cleanupDaemonThreads>false</cleanupDaemonThreads>
+        </configuration>
       </plugin>
     </plugins>
   </build>
@@ -283,14 +303,30 @@ public class SpannerOpenCensusTutorial {
 {{</tabs>}}
 
 ### Maven install
-## Running it
+
+## Saving the file
+Please save the Java source code in your current working directory under `src/main/java/com/opencensus/tutorials/SpannerOpenCensusTutorial.java`.
+Also save the `pom.xml` file in the same current working directory.
+
+Your current working directory's structure should then look like this.
+
 ```shell
-mvn install
+pom.xml
+src/
+  |-main
+    |-java
+      |-com
+        |-opencensus
+          |-tutorials
+            |-SpannerOpenCensusTutorial.java
 ```
 
-### Run the code
+## Running it
 ```shell
-mvn exec:java -Dexec.mainClass=com.opencensus.tutorials.spanner -Dexec.args="census-demos demo1"
+mvn install && \
+mvn exec:java \
+-Dexec.mainClass=com.opencensus.tutorials.SpannerOpenCensusTutorial \
+-Dexec.args="census-demos demo1"
 ```
 
 ## Viewing your metrics


### PR DESCRIPTION
Reported offline by Alex Amies, the Google Cloud Spanner integration
guide was outdated but also couldn't compile.

This change modernizes the guide to use OpenCensus-Java 0.18.0
(the lastest) up from 0.11.0 and the Cloud Spanner Java
dependency to 1.5.0, up from 0.33.0-beta

Also ensuring that the guides run/compile successfully/end-to-end.

This change also ran `./gradlew goJF` on the Java source code
as well as followed Alex's recommendation of removing usages
of "this.*" except when dealing with scoping problems, as that style
is the norm in Java.

Supersedes #540