### PR TITLE
quickstart: add C# on listing

### DIFF
--- a/layouts/shortcodes/quickstart-list.html
+++ b/layouts/shortcodes/quickstart-list.html
@@ -1,4 +1,16 @@
 <div class="quickstart-list-header">
+  <img src="/images/dotnetcore.png">
+  <h5>C#</h5>
+</div>
+
+<a
+  class="btn btn-info"
+  onclick="location.href='dotnet/tracing'"
+>
+Tracing
+</a>
+
+<div class="quickstart-list-header">
   <img src="/images/cpp.png">
   <h5>C++</h5>
 </div>


### PR DESCRIPTION
The C# logo and shortcut to quickstarts was missing
on the "Quickstart" landing page.

### Before
![screen shot 2019-01-20 at 11 51 06 pm](https://user-images.githubusercontent.com/4898263/51459713-4ff95a00-1d0e-11e9-8a47-16b5acae711f.png)


### After
![screen shot 2019-01-20 at 11 51 41 pm](https://user-images.githubusercontent.com/4898263/51459729-5be51c00-1d0e-11e9-9e13-c92e2b1397e4.png)

/cc @simonz130