### PR TITLE
content/exporters: update Datadog Go exporter example

### DIFF
--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -80,6 +80,9 @@ func main() {
 
   // Register it as a metrics exporter
   trace.RegisterExporter(dd)
+
+  // Allow Datadog to calculate APM metrics and do the sampling.
+  trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 }
 {{</highlight>}}
 
@@ -107,6 +110,9 @@ func main() {
 
   // Register it as a metrics exporter
   trace.RegisterExporter(dd)
+
+  // Allow Datadog to calculate APM metrics and do the sampling.
+  trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 }
 {{</highlight>}}
 {{</tabs>}}


### PR DESCRIPTION
This change specifies the need for setting `AlwaysSample` when using the
Datadog exporter, in order to get accurate APM metrics (and sampling)
within the Datadog product.