### PR TITLE
Added links to Go and Java APIs

### DIFF
--- a/content/guides/http/_index.md
+++ b/content/guides/http/_index.md
@@ -17,5 +17,5 @@ OpenCensus can be used with HTTP packages, frameworks and plugins in the followi
 
 Resource|URL
 ---|---
-HTTP guide Mozilla Developer Network|https://developer.mozilla.org/en-US/docs/Web/HTTP
-IETF RFC 2616|https://www.ietf.org/rfc/rfc2616.txt
+Go ochttp package documentation|https://godoc.org/go.opencensus.io/plugin/ochttp
+Java HTTP Servlet plugin repository|https://github.com/census-instrumentation/opencensus-java/tree/master/contrib/http_servlet


### PR DESCRIPTION
I noticed that there is no HTTP Java integration on the web site Integration Guide page. I think that we could improve that, at least by adding the links to the page with the Java contrib code examples here

https://github.com/census-instrumentation/opencensus-java/tree/master/examples#to-run-http-server-and-client

The existing links at the bottom of the page do not make sense. One goes to a generic page at Mozilla and one goes to the IETF standard for HTTP. This PR replaces them with links to the Go and Java API resources.