### PR TITLE
Fix 404 on TagContext spec

### DIFF
--- a/content/tag/_index.md
+++ b/content/tag/_index.md
@@ -64,7 +64,7 @@ Tags are key-value used to filter and group metrics while annotations are used t
 
 Resource|URL
 ---|---
-TagContext in OpenCensus specs|[TagContext API](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md)
+TagContext in OpenCensus specs|[TagContext API](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md)
 Go tag package|https://godoc.org/go.opencensus.io/tag
 Java tags package|[Tags API JavaDoc](https://static.javadoc.io/io.opencensus/opencensus-api/0.16.1/io/opencensus/tags/package-frame.html)
 Python tags package|[Tags API implementation](https://github.com/census-instrumentation/opencensus-python/tree/master/opencensus/tags)

--- a/content/tag/key.md
+++ b/content/tag/key.md
@@ -55,7 +55,7 @@ const keyMethod = "method";
 
 Resource|URL
 ---|---
-Specs definition|[specs/TagContext.TagKey](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md#tagkey)
+Specs definition|[specs/TagContext.TagKey](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#tagkey)
 Go TagKey API|[TagKey](https://godoc.org/go.opencensus.io/tag#Key)
 Java TagKey API|[TagKey JavaDoc](https://static.javadoc.io/io.opencensus/opencensus-api/0.16.1/io/opencensus/tags/TagKey.html)
 Python TagKey reference|[Github implementation](https://github.com/census-instrumentation/opencensus-python/blob/fc42d70f0c9f423b22d0d6a55cc1ffb0e3e478c8/opencensus/tags/tag_key.py#L15-L34)

--- a/content/tag/map.md
+++ b/content/tag/map.md
@@ -84,6 +84,6 @@ const keyMethod = "method";
 
 Resource|URL
 ---|---
-Specs reference|[specs.TagContext](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md#tag-context-api)
+Specs reference|[specs.TagContext](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#tagmap)
 Go reference|[tag.New](https://godoc.org/go.opencensus.io/tag#New)
 Java reference|[TagContext](https://static.javadoc.io/io.opencensus/opencensus-api/0.16.1/io/opencensus/tags/TagContext.html)

--- a/content/tag/serialization.md
+++ b/content/tag/serialization.md
@@ -23,6 +23,6 @@ The "combined size" restriction applies to deserialized tags so that the set of 
 
 Resource|URL
 ---|---
-Serialization specs reference|[specs/TagContext.Serialization](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md#serialization)
-Error handling specs reference|[specs/TagContext.Serialization.ErrorHandling](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md#error-handling)
+Serialization specs reference|[specs/TagContext.Serialization](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#encoding)
+Error handling specs reference|[specs/TagContext.Serialization.ErrorHandling](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#error-handling)
 

--- a/content/tag/value.md
+++ b/content/tag/value.md
@@ -51,7 +51,7 @@ const methodValue = "memcache.Client.Get";
 
 Resource|URL
 ---|---
-Specs reference|[specs/TagContext.TagValue](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagContext.md#tagvalue)
+Specs reference|[specs/TagContext.TagValue](https://github.com/census-instrumentation/opencensus-specs/blob/master/tags/TagMap.md#tagvalue)
 Go TagValue API|[TagMutator](https://godoc.org/go.opencensus.io/tag#Mutator)
 Java TagValue API|[TagValue JavaDoc](https://static.javadoc.io/io.opencensus/opencensus-api/0.16.1/io/opencensus/tags/TagValue.html)
 Python TagValue reference|[Github implementation](https://github.com/census-instrumentation/opencensus-python/blob/fc42d70f0c9f423b22d0d6a55cc1ffb0e3e478c8/opencensus/tags/tag_value.py#L15-L34)


### PR DESCRIPTION
Current link to specs/TagContext are wrong due to a renaming of TagContext.md into TagMap.md