### PR TITLE
Fix undefined variable in the example code.

### DIFF
--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -106,7 +106,7 @@ func main() {
   defer dd.Stop()
 
   // Register it as a metrics exporter
-  view.RegisterExporter(sd)
+  view.RegisterExporter(dd)
 
   // Register it as a metrics exporter
   trace.RegisterExporter(dd)


### PR DESCRIPTION
I think, sd variable copied from another code by mistake. The build is taking error:
./main.go:20:25: undefined: sd
The variable should be dd.