### PR TITLE
content/exporters: update Jaeger endpoint.

### DIFF
--- a/content/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/exporters/supported-exporters/Go/Jaeger.md
@@ -49,12 +49,12 @@ import (
 func main() {
 	// Port details: https://www.jaegertracing.io/docs/getting-started/
 	agentEndpointURI := "localhost:6831"
-	collectorEndpointURI := "http://localhost:14268/"
+	collectorEndpointURI := "http://localhost:14268/api/traces"
 
 	je, err := jaeger.NewExporter(jaeger.Options{
-		AgentEndpoint: agentEndpointURI,
-		Endpoint:      collectorEndpointURI,
-		ServiceName:   "demo",
+		AgentEndpoint:          agentEndpointURI,
+		CollectorEndpoint:      collectorEndpointURI,
+		ServiceName:            "demo",
 	})
 	if err != nil {
 		log.Fatalf("Failed to create the Jaeger exporter: %v", err)

--- a/content/exporters/supported-exporters/Go/Jaeger.md
+++ b/content/exporters/supported-exporters/Go/Jaeger.md
@@ -49,7 +49,7 @@ import (
 func main() {
 	// Port details: https://www.jaegertracing.io/docs/getting-started/
 	agentEndpointURI := "localhost:6831"
-	collectorEndpointURI := "http://localhost:14268/api/traces"
+	collectorEndpointURI := "http://localhost:14268/"
 
 	je, err := jaeger.NewExporter(jaeger.Options{
 		AgentEndpoint: agentEndpointURI,

--- a/content/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/exporters/supported-exporters/Java/Jaeger.md
@@ -69,7 +69,7 @@ import io.opencensus.exporter.trace.jaeger.JaegerTraceExporter;
 
 public class JaegerTutorial {
     public static void main(String ...args) throws Exception {
-        JaegerTraceExporter.createAndRegister("http://127.0.0.1:14268/api/traces", "service-b");
+        JaegerTraceExporter.createAndRegister("http://127.0.0.1:14268/", "service-b");
     }
 }
 {{</highlight>}}

--- a/content/exporters/supported-exporters/Java/Jaeger.md
+++ b/content/exporters/supported-exporters/Java/Jaeger.md
@@ -69,7 +69,7 @@ import io.opencensus.exporter.trace.jaeger.JaegerTraceExporter;
 
 public class JaegerTutorial {
     public static void main(String ...args) throws Exception {
-        JaegerTraceExporter.createAndRegister("http://127.0.0.1:14268/", "service-b");
+        JaegerTraceExporter.createAndRegister("http://127.0.0.1:14268/api/traces", "service-b");
     }
 }
 {{</highlight>}}


### PR DESCRIPTION
Reported by @bzon:

> the Jaeger collector endpoint address in this documentation is wrong https://opencensus.io/exporters/supported-exporters/go/jaeger/.

> It should just be http://localhost:14268 and not http://localhost:14268/api/traces. I used the all-in-one docker image of jaeger when following the guide.