### PR TITLE
Update tag value documentation Python example.

### DIFF
--- a/content/tag/value.md
+++ b/content/tag/value.md
@@ -27,6 +27,7 @@ mutator = tag.Upsert(keyMethod, "memcache.Client.Get")
 {{<highlight python>}}
 import opencensus.tags import tag_value
 
+value = tag_value.TagValue('memcache.Client.Get')
 {{</highlight>}}
 
 {{<highlight java>}}


### PR DESCRIPTION
The example previously had an import only. Add an example in the same vein as the Java example.