### PR TITLE
Update python examples for exporter package move

### DIFF
--- a/content/exporters/supported-exporters/Python/ApplicationInsights.md
+++ b/content/exporters/supported-exporters/Python/ApplicationInsights.md
@@ -25,33 +25,33 @@ To learn about Local Forwarder and how to set it up, visit [this link](https://d
 Here's an example of setting things up on the OpenCensus side (see [Local Forwarder repo](https://github.com/Microsoft/ApplicationInsights-LocalForwarder/blob/master/examples/opencensus/python-app/app/views.py) for the most up-to-date example):
 
 {{<highlight python>}}
+import os
+import time
+
 from django.http import HttpResponse
 from django.shortcuts import render
+import requests
 
 from opencensus.common.async.transports.async_ import AsyncTransport
 from opencensus.trace import config_integration
-from opencensus.trace import tracer as tracer_module
-from opencensus.trace.exporters.ocagent import trace_exporter
+from opencensus.trace.tracer import Tracer
+from opencensus.ext.ocagent.trace_exporter import TraceExporter
 from opencensus.trace.propagation.trace_context_http_header_format import TraceContextPropagator
 
-import time
-import os
-import requests
+INTEGRATIONS = ["httplib"]
 
-INTEGRATIONS = ['httplib']
-
-service_name = os.getenv('SERVICE_NAME', 'python-service')
-config_integration.trace_integrations(INTEGRATIONS, tracer=tracer_module.Tracer(
-    exporter=trace_exporter.TraceExporter(
-        service_name=service_name,
-        endpoint=os.getenv('OCAGENT_TRACE_EXPORTER_ENDPOINT'),
-        transport=AsyncTransport),
-    propagator=TraceContextPropagator()))
-
+service_name = os.getenv("SERVICE_NAME", "python-service")
+config_integration.trace_integrations(
+    INTEGRATIONS,
+    tracer=Tracer(
+        exporter=TraceExporter(
+            service_name=service_name,
+            endpoint=os.getenv("OCAGENT_TRACE_EXPORTER_ENDPOINT"),
+            transport=AsyncTransport),
+        propagator=TraceContextPropagator()))
 
 def call(request):
     requests.get("http://go-app:50030/call")
-
     return HttpResponse("hello world from " + service_name)
 {{</highlight>}}
 

--- a/content/exporters/supported-exporters/Python/Honeycomb.md
+++ b/content/exporters/supported-exporters/Python/Honeycomb.md
@@ -35,31 +35,31 @@ To create the exporter, we'll need to:
 - Pass in your Honeycomb dataset name
 
 {{<highlight python>}}
-import time
 import os
+import time
 
-from opencensus.trace import tracer as tracer_module
 from ochoneycomb import HoneycombExporter
+from opencensus.trace.tracer import Tracer
 
-exporter = HoneycombExporter(writekey=os.getenv("HONEYCOMB_WRITEKEY"),
-                             dataset=os.getenv("HONEYCOMB_DATASET"),
-                             service_name="test-app")
-tracer = tracer_module.Tracer(exporter=exporter)
-
+exporter = HoneycombExporter(
+    writekey=os.getenv("HONEYCOMB_WRITEKEY"),
+    dataset=os.getenv("HONEYCOMB_DATASET"),
+    service_name="test-app")
+tracer = Tracer(exporter=exporter)
 
 def do_something_to_trace():
     time.sleep(1)
 
-
 # Example for creating nested spans
-with tracer.span(name='span1') as span1:
+with tracer.span(name="span1") as span1:
     do_something_to_trace()
-    with tracer.span(name='span1_child1') as span1_child1:
+    with tracer.span(name="span1_child1") as span1_child1:
         span1_child1.add_annotation("something")
         do_something_to_trace()
-    with tracer.span(name='span1_child2') as span1_child2:
+    with tracer.span(name="span1_child2") as span1_child2:
         do_something_to_trace()
-with tracer.span(name='span2') as span2:
+
+with tracer.span(name="span2") as span2:
     do_something_to_trace()
 {{</highlight>}}
 

--- a/content/exporters/supported-exporters/Python/Jaeger.md
+++ b/content/exporters/supported-exporters/Python/Jaeger.md
@@ -38,19 +38,20 @@ To create the exporter, we'll need to:
 {{<highlight python>}}
 #!/usr/bin/env python
 
-from opencensus.trace.exporters.jaeger_exporter import JaegerExporter
+from opencensus.ext.jaeger.trace_exporter import JaegerExporter
 from opencensus.trace.tracer import Tracer
 
 def main():
-    je = JaegerExporter(service_name="service-b",
-                        host_name='localhost',
-                        agent_port=6831,
-                        endpoint='/api/traces')
+    je = JaegerExporter(
+        service_name="service-b",
+        host_name="localhost",
+        agent_port=6831,
+        endpoint="/api/traces")
 
     tracer = Tracer(exporter=je)
-    with tracer.span(name='doingWork') as span:
+    with tracer.span(name="doingWork") as span:
         for i in range(10):
-            continue
+            pass
 
 if __name__ == "__main__":
     main()

--- a/content/exporters/supported-exporters/Python/Stackdriver.md
+++ b/content/exporters/supported-exporters/Python/Stackdriver.md
@@ -46,18 +46,18 @@ Instrument your code with the following snippet:
 import os
 
 from opencensus.common.transports.async_ import AsyncTransport
-from opencensus.trace.exporters import stackdriver_exporter
+from opencensus.ext.stackdriver.trace_exporter import StackdriverExporter
 from opencensus.trace.tracer import Tracer
 
 def main():
-    sde = stackdriver_exporter.StackdriverExporter(
-                project_id=os.environ.get("GCP_PROJECT_ID"),
-                transport=AsyncTransport)
+    sde = StackdriverExporter(
+        project_id=os.environ.get("GCP_PROJECT_ID"),
+        transport=AsyncTransport)
 
     tracer = Tracer(exporter=sde)
-    with tracer.span(name='doingWork') as span:
+    with tracer.span(name="doingWork") as span:
         for i in range(10):
-            continue
+            pass
 
 if __name__ == "__main__":
     main()

--- a/content/exporters/supported-exporters/Python/Zipkin.md
+++ b/content/exporters/supported-exporters/Python/Zipkin.md
@@ -33,19 +33,20 @@ To create the exporter, we'll need to:
 {{<highlight python>}}
 #!/usr/bin/env python
 
-from opencensus.trace.exporters.zipkin_exporter import ZipkinExporter
+from opencensus.ext.zipkin.trace_exporter import ZipkinExporter
 from opencensus.trace.tracer import Tracer
 
 def main():
-    ze = ZipkinExporter(service_name="service-a",
-                        host_name='localhost',
-                        port=9411,
-                        endpoint='/api/v2/spans')
+    ze = ZipkinExporter(
+        service_name="service-a",
+        host_name="localhost",
+        port=9411,
+        endpoint="/api/v2/spans")
 
     tracer = Tracer(exporter=ze)
-    with tracer.span(name='doingWork') as span:
+    with tracer.span(name="doingWork") as span:
         for i in range(10):
-            continue
+            pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR updates the python examples to reflect the [move to separate exporter packages](https://github.com/census-instrumentation/opencensus-python/pull/550), and does some incidental cleanup.

Fixes #664.