### PR TITLE
Fixed broken link to supported exported

### DIFF
--- a/content/exporters/custom-exporter/Go/Metrics.md
+++ b/content/exporters/custom-exporter/Go/Metrics.md
@@ -157,4 +157,4 @@ Name|Link
 ---|---
 Metrics/Stats GoDoc for Measures|[https://godoc.org/go.opencensus.io/stats](https://godoc.org/go.opencensus.io/stats)
 Stats View GoDoc|[https://godoc.org/go.opencensus.io/stats/view](https://godoc.org/go.opencensus.io/stats/view)
-OpenCensus Go exporters|[Some OpenCensus Go exporters](/supported-exporters/go/)
+OpenCensus Go exporters|[Some OpenCensus Go exporters](/exporters/supported-exporters/go/)


### PR DESCRIPTION
The existing page at 

https://opencensus.io/exporters/custom-exporter/go/metrics/

leads to a 404