### PR TITLE
integrations/ocjdbc: upgrade to v0.0.4

### DIFF
--- a/content/integrations/sql/java_sql.md
+++ b/content/integrations/sql/java_sql.md
@@ -37,23 +37,23 @@ but also distributed as Maven, Gradle, Ivy and Builder artifacts as you'll short
 <dependency>
     <groupId>io.orijtech.integrations</groupId>
     <artifactId>ocjdbc</artifactId>
-    <version>0.0.3</version>
+    <version>0.0.4</version>
 </dependency>
 {{</highlight>}}
 
 {{<highlight gradle>}}
 // https://mvnrepository.com/artifact/io.orijtech.integrations/ocjdbc
-compile group: 'io.orijtech.integrations', name: 'ocjdbc', version: '0.0.3'
+compile group: 'io.orijtech.integrations', name: 'ocjdbc', version: '0.0.4'
 {{</highlight>}}
 
 {{<highlight xml>}}
 <!-- https://mvnrepository.com/artifact/io.orijtech.integrations/ocjdbc -->
-<dependency org="io.orijtech.integrations" name="ocjdbc" rev="0.0.3"/>
+<dependency org="io.orijtech.integrations" name="ocjdbc" rev="0.0.4"/>
 {{</highlight>}}
 
 {{<highlight python>}}
 # https://mvnrepository.com/artifact/io.orijtech.integrations/ocjdbc
-'io.orijtech.integrations:ocjdbc:jar:0.0.3'
+'io.orijtech.integrations:ocjdbc:jar:0.0.4'
 {{</highlight>}}
 {{</tabs>}}
 
@@ -268,7 +268,7 @@ public class App {
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <opencensus.version>0.16.1</opencensus.version>
+        <opencensus.version>0.21.0</opencensus.version>
     </properties>
 
     <dependencies>
@@ -287,7 +287,7 @@ public class App {
         <dependency>
             <groupId>io.orijtech.integrations</groupId>
             <artifactId>ocjdbc</artifactId>
-            <version>0.0.3</version>
+            <version>0.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Following suit with:
* https://github.com/census-ecosystem/opencensus-java-jdbc/pull/59
* https://github.com/orijtech/opencensus-java-jdbc/pull/1
initiated by @dmichel1

Upgrade to updated ocjdbc version v0.0.4 which
also uses OpenCensus-Java v0.21.0 having taken
in a bug fix in OpenCensus v0.18.0 that reduced
high CPU usage for low QPS services.