### PR TITLE
replace exporter registration with start/stop for stackdriver exp.

### DIFF
--- a/content/exporters/supported-exporters/Go/Prometheus.md
+++ b/content/exporters/supported-exporters/Go/Prometheus.md
@@ -66,9 +66,6 @@ func main() {
 		log.Fatalf("Failed to create Prometheus exporter: %v", err)
 	}
 
-	// Ensure that we register it as a stats exporter.
-	view.RegisterExporter(pe)
-
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", pe)

--- a/content/exporters/supported-exporters/Go/Stackdriver.md
+++ b/content/exporters/supported-exporters/Go/Stackdriver.md
@@ -76,10 +76,10 @@ func main() {
 	}
 	// It is imperative to invoke flush before your main function exits
 	defer sd.Flush()
-
-	// Register it as a metrics exporter
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(60 * time.Second)
+	
+	// Start metric exporter
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 }
 {{</highlight>}}
 
@@ -134,9 +134,9 @@ func main() {
 	// It is imperative to invoke flush before your main function exits
 	defer sd.Flush()
 
-	// Register it as a metrics exporter
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(60 * time.Second)
+	// Start metric exporter
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 
 	// Register it as a trace exporter
 	trace.RegisterExporter(sd)

--- a/content/guides/gRPC/Go.md
+++ b/content/guides/gRPC/Go.md
@@ -329,8 +329,8 @@ func main() {
 	}
 	defer sd.Flush()
 	trace.RegisterExporter(sd)
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(60 * time.Second)
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 	// For demo purposes let's always sample
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 
@@ -422,7 +422,8 @@ func main() {
 	}
 	defer sd.Flush()
 	trace.RegisterExporter(sd)
-	view.RegisterExporter(sd)
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 	// For demo purposes let's always sample
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 

--- a/content/guides/http/go/net_http/client.md
+++ b/content/guides/http/go/net_http/client.md
@@ -207,7 +207,6 @@ func enableObservabilityAndExporters() {
 		log.Fatalf("Failed to create the Prometheus stats exporter: %v", err)
 	}
 
-	view.RegisterExporter(pe)
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", pe)

--- a/content/integrations/google_cloud/google_cloud_spanner/Go.md
+++ b/content/integrations/google_cloud/google_cloud_spanner/Go.md
@@ -127,8 +127,9 @@ func main() {
 	// Enable tracing
 	trace.RegisterExporter(se)
 
-	// Enable metrics collection
-	view.RegisterExporter(se)
+	// Start metrics collection
+	se.StartMetricsExporter()
+	defer se.StopMetricsExporter()
 
 	// Register all the gRPC client views
 	if err := view.Register(ocgrpc.DefaultClientViews...); err != nil {

--- a/content/integrations/google_cloud/google_cloud_storage/Go.md
+++ b/content/integrations/google_cloud/google_cloud_storage/Go.md
@@ -137,8 +137,9 @@ func main() {
 	// Register the trace exporter
 	trace.RegisterExporter(sd)
 
-	// Register the stats exporter
-	view.RegisterExporter(sd)
+	// Start the metrics exporter
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 
 	ctx := context.Background()
 	gcsClient, err := storage.NewClient(ctx)

--- a/content/integrations/redis/Go/gomodule_redigo.md
+++ b/content/integrations/redis/Go/gomodule_redigo.md
@@ -166,8 +166,8 @@ func enableOpenCensus() (func(), error) {
 	if err := view.Register(redis.ObservabilityMetricViews...); err != nil {
 		return nil, err
 	}
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(60 * time.Second)
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 
 	return sd.Flush, nil
 }
@@ -248,8 +248,8 @@ func enableOpenCensus() (func(), error) {
 	if err := view.Register(redis.ObservabilityMetricViews...); err != nil {
 		return nil, err
 	}
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(50 * time.Millisecond)
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 
 	return sd.Flush, nil
 }
@@ -435,8 +435,8 @@ func enableOpenCensus() (func(), error) {
 	if err := view.Register(redis.ObservabilityMetricViews...); err != nil {
 		return nil, err
 	}
-	view.RegisterExporter(sd)
-	view.SetReportingPeriod(50 * time.Millisecond)
+	sd.StartMetricsExporter()
+	defer sd.StopMetricsExporter()
 
 	// Enable tracing
 	trace.RegisterExporter(sd)

--- a/content/integrations/sql/go_sql.md
+++ b/content/integrations/sql/go_sql.md
@@ -168,9 +168,6 @@ func enableOpenCensusObservability(mux *http.ServeMux) (fnStop func(), err error
 	// set up the prometheus exporter
 	prometheusExporter, err := prometheus.NewExporter(prometheus.Options{})
 	if err == nil {
-		// On success, register it as a metrics exporter
-		view.RegisterExporter(prometheusExporter)
-		view.SetReportingPeriod(5 * time.Second)
 		// provide /metrics endpoint for Prometheus to scrape from.
 		mux.Handle("/metrics", prometheusExporter)
 	}
@@ -451,9 +448,6 @@ func enableOpenCensusObservability(mux *http.ServeMux) (fnStop func(), err error
 	// set up the prometheus exporter
 	prometheusExporter, err := prometheus.NewExporter(prometheus.Options{})
 	if err == nil {
-		// On success, register it as a metrics exporter
-		view.RegisterExporter(prometheusExporter)
-		view.SetReportingPeriod(5 * time.Second)
 		// provide /metrics endpoint for Prometheus to scrape from.
 		mux.Handle("/metrics", prometheusExporter)
 	}

--- a/content/quickstart/go/metrics.md
+++ b/content/quickstart/go/metrics.md
@@ -1234,9 +1234,6 @@ func main() {
 		log.Fatalf("Failed to create the Prometheus stats exporter: %v", err)
 	}
 
-	// Register the Prometheus exporters as a stats exporter.
-	view.RegisterExporter(pe)
-
 	// Now finally run the Prometheus exporter as a scrape endpoint.
 	// We'll run the server on port 8888.
 	go func() {
@@ -1248,14 +1245,6 @@ func main() {
 	}()
 }
 ```
-
-### Register the exporter
-```go
-// Register the Prometheus exporter.
-// This step is needed so that metrics can be exported.
-view.RegisterExporter(pe)
-```
-
 
 ## End to end code
 Collectively the code will be
@@ -1335,9 +1324,6 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed to create the Prometheus stats exporter: %v", err)
 	}
-	// Register the Prometheus exporter.
-	// This step is needed so that metrics can be exported.
-	view.RegisterExporter(pe)
 
 	// Now finally run the Prometheus exporter as a scrape endpoint.
 	// We'll run the server on port 8888.


### PR DESCRIPTION
- for prometheus just remove the registration.

updates https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/188#issuecomment-526456067