### PR TITLE
.travis.yml: upgrade to Node.js 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: node_js
 
 node_js:
- - "7"
+ - "8"
 
 install:
  - npm install -g firebase-tools


### PR DESCRIPTION
Firebase seems to require a version of
Node.js >=8.0 as per the silent failure in
https://travis-ci.org/census-instrumentation/opencensus-website/builds/580447164

```shell
Firebase CLI v7.3.0 is incompatible with Node.js v7.10.1
Please upgrade Node.js to version >= 8.0.0
```

Fixes #713.