### PR TITLE
sample code: Fix import package name

### DIFF
--- a/content/exporters/supported-exporters/Go/DataDog.md
+++ b/content/exporters/supported-exporters/Go/DataDog.md
@@ -16,7 +16,7 @@ logo: /img/partners/datadog_logo.svg
 ## Introduction
 [Datadog](https://www.datadoghq.com/) is a real-time monitoring system that supports distributed tracing and monitoring.
 
-Its OpenCensus Go exporter is available at [https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog](https://godoc.org/github.com/Datadog/opencensus-go-exporter-datadog)
+Its OpenCensus Go exporter is available at [https://godoc.org/github.com/DataDog/opencensus-go-exporter-datadog](https://godoc.org/github.com/DataDog/opencensus-go-exporter-datadog)
 
 
 ## Creating the exporter
@@ -28,7 +28,7 @@ To create the exporter, we'll need:
 This is possible by importing the exporter
 
 {{<highlight go>}}
-import "github.com/Datadog/opencensus-go-exporter-datadog"
+import "github.com/DataDog/opencensus-go-exporter-datadog"
 
 // then create the actual exporter
 dd := datadog.NewExporter(datadog.Options{})
@@ -43,7 +43,7 @@ package main
 import (
   "log"
 
-  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "github.com/DataDog/opencensus-go-exporter-datadog"
   "go.opencensus.io/stats/view"
 )
 
@@ -66,7 +66,7 @@ package main
 import (
    "log"
 
-  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "github.com/DataDog/opencensus-go-exporter-datadog"
   "go.opencensus.io/trace"
 )
 
@@ -92,7 +92,7 @@ package main
 import (
   "log"
 
-  "github.com/Datadog/opencensus-go-exporter-datadog"
+  "github.com/DataDog/opencensus-go-exporter-datadog"
   "go.opencensus.io/stats/view"
   "go.opencensus.io/trace"
 )


### PR DESCRIPTION
I appreciate easy-to-understand documents.

Go language differentiates the case in package PATH. the correct `opencensus-go-exporter-datadog` repository PATH on GitHub is below.

https://github.com/DataDog/opencensus-go-exporter-datadog

But, it import path in sample codes is below:

https://opencensus.io/exporters/supported-exporters/go/datadog/

```go
package main

import (
  "log"

  "github.com/Datadog/opencensus-go-exporter-datadog"
  "go.opencensus.io/stats/view"
)

func main() {
  dd, err := datadog.NewExporter(datadog.Options{})
  if err != nil {
    log.Fatalf("Failed to create the Datadog exporter: %v", err)
  }
  // It is imperative to invoke flush before your main function exits
  defer dd.Stop()

  // Register it as a metrics exporter
  view.RegisterExporter(dd)
}
```

`Data"d"og` is not correct, the correct path is `Data"D"og`.

using Go1.13, go.mod(dependency file) is below:
```
module github.com/budougumi0617/til/go/datadog/opencensus

go 1.13

require (
        github.com/DataDog/datadog-go v2.2.0+incompatible // indirect
        github.com/Datadog/opencensus-go-exporter-datadog v0.0.0-20190926132405-fe3fae706db1
        github.com/philhofer/fwd v1.0.0 // indirect
        github.com/stretchr/testify v1.4.0 // indirect
        github.com/tinylib/msgp v1.1.0 // indirect
        go.opencensus.io v0.22.1
        gopkg.in/DataDog/dd-trace-go.v1 v1.18.0 // indirect
)
```


I think it should be unified to the correct import path.

Regards,