### PR TITLE
Synchronize Prometheus node.js exporter ports

### DIFF
--- a/content/exporters/supported-exporters/Node.js/Prometheus.md
+++ b/content/exporters/supported-exporters/Node.js/Prometheus.md
@@ -72,7 +72,7 @@ scrape_configs:
     scrape_interval: 10s
 
     static_configs:
-      - targets: ['localhost:8888']
+      - targets: ['localhost:9464']
 ```
 
 ## Running Prometheus


### PR DESCRIPTION
The port the node code used and the target port in the prometheus.yaml file were no the same. I've changed the port in the prometheus.yaml file to match the port in the node code.