### PR TITLE
Documentation: Python trace exporter to Datadog is supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ _site
 public/
 .DS_Store
 .idea/
+*.swp
+*.swo

--- a/content/exporters/supported-exporters/Python/DataDog.md
+++ b/content/exporters/supported-exporters/Python/DataDog.md
@@ -1,0 +1,30 @@
+---
+title: "Datadog (Stats and Tracing)"
+date: 2020-01-13T14:29:35-08:00
+draft: false
+weight: 3
+class: "resized-logo"
+aliases: [/supported-exporters/python/datadog, /guides/exporters/supported-exporters/python/datadog]
+logo: /img/partners/datadog_logo.svg
+---
+
+- [Introduction](#introduction)
+- [Creating the exporter](#creating-the-exporter)
+- [Viewing your metrics](#viewing-your-metrics)
+- [Viewing your traces](#viewing-your-traces)
+
+## Introduction
+[Datadog](https://www.datadoghq.com/) is a real-time monitoring system that supports distributed tracing and monitoring.
+
+## Creating the exporter
+To create the exporter, we'll need:
+* Datadog credentials which you can get from [Here](https://docs.datadoghq.com/getting_started/)
+* Create an exporter in code
+
+You can find examples of using the OpenCensus Python Datadog exporter [here](https://github.com/census-instrumentation/opencensus-python/tree/master/contrib/opencensus-ext-datadog/examples).
+
+## Viewing your metrics
+Please visit [https://docs.datadoghq.com/dashboards/](https://docs.datadoghq.com/dashboards/).
+
+## Viewing your traces
+Please visit [https://docs.datadoghq.com/tracing/](https://docs.datadoghq.com/tracing/)

--- a/layouts/shortcodes/feature-matrix.html
+++ b/layouts/shortcodes/feature-matrix.html
@@ -50,7 +50,7 @@
 		<td data-label="java"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr></td>
 		<td data-label="nodejs">–</td>
 		<td data-label="php">–</td>
-		<td data-label="python">–</td>
+		<td data-label="python"><abbr title="Trace Exporter" class="trace-exporter blue white-text">T</abbr></td>
 		<td data-label="ruby">–</td>
 	</tr>
 


### PR DESCRIPTION
Follow-up of https://github.com/census-instrumentation/opencensus-python/pull/793 and https://github.com/census-instrumentation/opencensus-python/pull/799, I found that the Datadog exporter for traces in Python doesn't appear to be supported on the opencensus.io website when it's in fact supported.

Example 1: missing datadog
![image](https://user-images.githubusercontent.com/7011464/72633635-b8711c00-390d-11ea-9c68-81aa35a00fe4.png)

Example 2: missing "T" in the Python/Datadog intersection
![image](https://user-images.githubusercontent.com/7011464/72633764-02f29880-390e-11ea-9f32-d5438675830c.png)