### PR TITLE
Update grpc-gateway references

### DIFF
--- a/content/service/components/agent/_index.md
+++ b/content/service/components/agent/_index.md
@@ -22,7 +22,7 @@ to the centralized point before they are exported to the target backends.
 By default, ocagent runs on TCP port `55678` and receives traffic from:
 
 * HTTP/2 clients with Protobuf messages
-* HTTP/1 clients that use the [grpc-web-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
+* HTTP/1 clients that use the [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
 
 ocagent is written in the [Go programming language](https://golang.org/), it is cross platform, self-monitored and receives traffic
 from any application that supports the [ocagent protocol](https://github.com/census-instrumentation/opencensus-proto/tree/master/src/opencensus/proto/agent) or from
@@ -83,5 +83,5 @@ Resource|URL
 OpenCensus Agent Protocol|[ocagent-protocol](https://github.com/census-instrumentation/opencensus-proto/tree/master/src/opencensus/proto/agent)
 OpenCensus Agent Design|[ocagent design doc](https://github.com/census-instrumentation/opencensus-service/blob/master/DESIGN.md#opencensus-agent)
 OpenCensus Collector Design|[occollector design doc](https://github.com/census-instrumentation/opencensus-service/blob/master/DESIGN.md#opencensus-collector)
-grpc-web-gateway|[grpc-web-gateway on GitHub](https://github.com/grpc-ecosystem/grpc-gateway)
+grpc-gateway|[grpc-gateway on GitHub](https://github.com/grpc-ecosystem/grpc-gateway)
 OpenCensus PHP design|[Design doc](https://docs.google.com/document/d/1CRiRq_wpzOuG9VKM_eaImcrS12Iie2V7LePnH9AwclU/)

--- a/content/service/receivers/opencensus/_index.md
+++ b/content/service/receivers/opencensus/_index.md
@@ -23,7 +23,7 @@ Protocol](https://github.com/census-instrumentation/opencensus-proto/tree/master
 By default, the OpenCensus Service listens on TCP port `55678` and receives traffic from:
 
 * HTTP/2 clients with Protobuf messages
-* HTTP/1 clients that use the [grpc-web-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
+* HTTP/1 clients that use the [grpc-gateway](https://github.com/grpc-ecosystem/grpc-gateway)
 
 ### Configuration
 An OpenCensus receiver can be turned on by using the configuration file
@@ -76,7 +76,7 @@ Node.js|[opencensus-node-exporter](https://github.com/census-instrumentation/ope
 Resource|URL
 ---|---
 OpenCensus Protocol|[opencensus protocol](https://github.com/census-instrumentation/opencensus-proto/tree/master/src/opencensus/proto/agent)
-grpc-web-gateway|https://github.com/grpc-ecosystem/grpc-gateway
+grpc-gateway|https://github.com/grpc-ecosystem/grpc-gateway
 Go exporter|[opencensus-go-exporter](/exporters/supported-exporters/go/ocagent/)
 Python exporter|[opencensus-python-exporter](https://github.com/census-instrumentation/opencensus-python/tree/master/opencensus/trace/exporters/ocagent)
 Java exporter|[opencensus-java-trace-exporter](https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/trace/ocagent) and [opencensus-java-metrics-exporter](https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/metrics/ocagent)


### PR DESCRIPTION

Use "grpc-gateway" phrasing to avoid confusion between
the JSON gateway and the grpc-web protocol.