### PR TITLE
Change title card on main page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -7,7 +7,7 @@ class: "no-pagination no-top-border-header no-search max-text-width"
 
 {{<title-card>}}
 
-> OpenCensus and OpenTracing have merged to form [OpenTelemetry](https://opentelemetry.io), which serves as the next major version of OpenCensus and OpenTracing. OpenTelemetry will offer backwards compatibility with existing OpenCensus integrations, and we will continue to make security patches to existing OpenCensus libraries for two years.
+> OpenCensus and OpenTracing have merged to form [OpenTelemetry](https://opentelemetry.io), which will become the next major version of OpenCensus and OpenTracing. OpenTelemetry will offer backwards compatibility with existing OpenCensus integrations, and we will continue to make security patches to existing OpenCensus libraries for two years. To keep up to date with news and progress of OpenTelemetry, refer to the OpenTelemetry [blog](https://medium.com/opentelemetry).
 
 ##### What is OpenCensus?
 


### PR DESCRIPTION
A couple of customers have been confused with the status of OpenTelemetry. From the main page, they perceived that OpenTelemetry is already a production ready set of libraries (GA/stable), which is not the case.

Changes the tense to "will" to reflect current status of OpenTelemetry project. Also adds a link to the blog to direct users to progress.