### PR TITLE
Open header to alert that OpenCensus is being archived

### DIFF
--- a/static/css/header.css
+++ b/static/css/header.css
@@ -44,13 +44,13 @@ a.btn.btn-light.opentelemetry-button {
 a.btn.btn-light.opentelemetry-button {
   margin-bottom: 0;
   color: #fff;
-  background: #75af00;
-  border: 1px solid #75af00;
+  background: #e2940f;
+  border: 1px solid #e2940f;
 }
 
 a.btn.btn-light.opentelemetry-button:hover {
   color: #fff;
-  background: #75af00;
+  background: #e2940f;
 }
 
 .mobile-opentelemetry {
@@ -65,11 +65,15 @@ a.btn.btn-light.opentelemetry-button:hover {
 }
 
 @media (max-width: 768px) {
-  header .header-opentelemetry {
+  header.header-opentelemetry {
     display: none;
   }
 
   .mobile-opentelemetry {
     display: block;
+  }
+
+  article {
+    margin-top: 0;
   }
 }

--- a/themes/docdock/layouts/partials/flex/body-beforecontent.html
+++ b/themes/docdock/layouts/partials/flex/body-beforecontent.html
@@ -1,4 +1,4 @@
-<header>
+<header class="header-opentelemetry">
   <div class="logo">
     {{ partial "header.html" . }}
   </div>
@@ -15,7 +15,7 @@
     </nav>
   {{- end}}
   <div class="opentelemetry-note">
-    <a class="opentelemetry-button btn btn-light" target="_blank" href="https://opentelemetry.io">OpenCensus and OpenTracing have merged into OpenTelemetry!</a>
+    <a class="opentelemetry-button btn btn-light" target="_blank" href="https://opentelemetry.io/blog/2023/sunsetting-opencensus/">OpenCensus is being archived! Read the blog post to learn more</a>
   </div>
 </header>
 <article>
@@ -40,7 +40,7 @@
   </aside>
   <section class="page {{ .Params.class }}">
     <div class="mobile-opentelemetry">
-      <a class="btn btn-light opentelemetry-button" target="_blank" href="https://opentelemetry.io">OpenCensus and OpenTracing have merged into OpenTelemetry!</a>
+      <a class="btn btn-light opentelemetry-button" target="_blank" href="https://opentelemetry.io/blog/2023/sunsetting-opencensus/">OpenCensus is being archived! Read the blog post to learn more</a>
     </div>
     <div class="nav-select">
       <center>Navigation :


### PR DESCRIPTION
- Updated text
- Updated the color
- Fixed mobile issues where header is displayed twice

### Before
<img width="627" alt="Screenshot 2023-05-04 at 7 22 45 PM" src="https://user-images.githubusercontent.com/1510004/236350402-572ca4c3-1ebe-42b0-9dc1-8029aabe4144.png">

### After
<img width="822" alt="Screenshot 2023-05-04 at 7 21 47 PM" src="https://user-images.githubusercontent.com/1510004/236350314-d5d9b851-d064-4d03-8bc2-bf70295731d1.png">

<img width="635" alt="Screenshot 2023-05-04 at 7 22 14 PM" src="https://user-images.githubusercontent.com/1510004/236350356-9a24652d-867d-44ab-b6db-da866b9299d7.png">
